### PR TITLE
Add Arbitrary::arbitrary_take_rest

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     /// There was not enough underlying data to fulfill some request for raw
     /// bytes.
     NotEnoughData,
+    /// The input bytes were not of the right format
+    IncorrectFormat,
 }
 
 impl fmt::Display for Error {
@@ -15,6 +17,10 @@ impl fmt::Display for Error {
             Error::NotEnoughData => write!(
                 f,
                 "There is not enough underlying raw data to construct an `Arbitrary` instance"
+            ),
+            Error::IncorrectFormat => write!(
+                f,
+                "The raw data is not of the correct format to construct this type"
             ),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1076,6 +1076,23 @@ mod test {
     }
 
     #[test]
+    fn arbitrary_take_rest() {
+        let x = [1, 2, 3, 4];
+        assert_eq!(
+            Vec::<u8>::arbitrary_take_rest(Unstructured::new(&x)).unwrap(),
+            &[1, 2, 3, 4]
+        );
+        assert_eq!(
+            Vec::<u32>::arbitrary_take_rest(Unstructured::new(&x)).unwrap(),
+            &[0x4030201]
+        );
+        assert_eq!(
+            String::arbitrary_take_rest(Unstructured::new(&x)).unwrap(),
+            "\x01\x02\x03\x04"
+        );
+    }
+
+    #[test]
     fn shrink_tuple() {
         let tup = (10, 20, 30);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -798,6 +798,13 @@ impl Arbitrary for String {
             .map(Into::into)
     }
 
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        let bytes = u.take_rest();
+        str::from_utf8(bytes)
+            .map_err(|_| Error::IncorrectFormat)
+            .map(Into::into)
+    }
+
     fn size_hint() -> (usize, Option<usize>) {
         crate::size_hint::and(<usize as Arbitrary>::size_hint(), (0, None))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ use std::iter;
 use std::mem;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::str;
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -791,9 +792,10 @@ where
 impl Arbitrary for String {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
         let size = u.arbitrary_len::<u8>()?;
-        (0..size)
-            .map(|_| <char as Arbitrary>::arbitrary(u))
-            .collect()
+        let bytes = u.get_bytes(size)?;
+        str::from_utf8(bytes)
+            .map_err(|_| Error::IncorrectFormat)
+            .map(Into::into)
     }
 
     fn size_hint() -> (usize, Option<usize>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,8 +616,7 @@ fn shrink_collection<'a, T, A: Arbitrary>(
 
 impl<A: Arbitrary> Arbitrary for Vec<A> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<A>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -631,8 +630,7 @@ impl<A: Arbitrary> Arbitrary for Vec<A> {
 
 impl<K: Arbitrary + Ord, V: Arbitrary> Arbitrary for BTreeMap<K, V> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<(K, V)>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -648,8 +646,7 @@ impl<K: Arbitrary + Ord, V: Arbitrary> Arbitrary for BTreeMap<K, V> {
 
 impl<A: Arbitrary + Ord> Arbitrary for BTreeSet<A> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<A>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -664,8 +661,7 @@ impl<A: Arbitrary + Ord> Arbitrary for BTreeSet<A> {
 
 impl<A: Arbitrary + Ord> Arbitrary for BinaryHeap<A> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<A>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -680,8 +676,7 @@ impl<A: Arbitrary + Ord> Arbitrary for BinaryHeap<A> {
 
 impl<K: Arbitrary + Eq + ::std::hash::Hash, V: Arbitrary> Arbitrary for HashMap<K, V> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<(K, V)>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -697,8 +692,7 @@ impl<K: Arbitrary + Eq + ::std::hash::Hash, V: Arbitrary> Arbitrary for HashMap<
 
 impl<A: Arbitrary + Eq + ::std::hash::Hash> Arbitrary for HashSet<A> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<A>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -713,8 +707,7 @@ impl<A: Arbitrary + Eq + ::std::hash::Hash> Arbitrary for HashSet<A> {
 
 impl<A: Arbitrary> Arbitrary for LinkedList<A> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<A>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -729,8 +722,7 @@ impl<A: Arbitrary> Arbitrary for LinkedList<A> {
 
 impl<A: Arbitrary> Arbitrary for VecDeque<A> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<A>()?;
-        (0..size).map(|_| Arbitrary::arbitrary(u)).collect()
+        u.arbitrary_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,6 +619,10 @@ impl<A: Arbitrary> Arbitrary for Vec<A> {
         u.arbitrary_iter()?.collect()
     }
 
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
+    }
+
     fn size_hint() -> (usize, Option<usize>) {
         crate::size_hint::and(<usize as Arbitrary>::size_hint(), (0, None))
     }
@@ -631,6 +635,10 @@ impl<A: Arbitrary> Arbitrary for Vec<A> {
 impl<K: Arbitrary + Ord, V: Arbitrary> Arbitrary for BTreeMap<K, V> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
         u.arbitrary_iter()?.collect()
+    }
+
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -649,6 +657,10 @@ impl<A: Arbitrary + Ord> Arbitrary for BTreeSet<A> {
         u.arbitrary_iter()?.collect()
     }
 
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
+    }
+
     fn size_hint() -> (usize, Option<usize>) {
         crate::size_hint::and(<usize as Arbitrary>::size_hint(), (0, None))
     }
@@ -664,6 +676,10 @@ impl<A: Arbitrary + Ord> Arbitrary for BinaryHeap<A> {
         u.arbitrary_iter()?.collect()
     }
 
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
+    }
+
     fn size_hint() -> (usize, Option<usize>) {
         crate::size_hint::and(<usize as Arbitrary>::size_hint(), (0, None))
     }
@@ -677,6 +693,10 @@ impl<A: Arbitrary + Ord> Arbitrary for BinaryHeap<A> {
 impl<K: Arbitrary + Eq + ::std::hash::Hash, V: Arbitrary> Arbitrary for HashMap<K, V> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
         u.arbitrary_iter()?.collect()
+    }
+
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -695,6 +715,10 @@ impl<A: Arbitrary + Eq + ::std::hash::Hash> Arbitrary for HashSet<A> {
         u.arbitrary_iter()?.collect()
     }
 
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
+    }
+
     fn size_hint() -> (usize, Option<usize>) {
         crate::size_hint::and(<usize as Arbitrary>::size_hint(), (0, None))
     }
@@ -710,6 +734,10 @@ impl<A: Arbitrary> Arbitrary for LinkedList<A> {
         u.arbitrary_iter()?.collect()
     }
 
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
+    }
+
     fn size_hint() -> (usize, Option<usize>) {
         crate::size_hint::and(<usize as Arbitrary>::size_hint(), (0, None))
     }
@@ -723,6 +751,10 @@ impl<A: Arbitrary> Arbitrary for LinkedList<A> {
 impl<A: Arbitrary> Arbitrary for VecDeque<A> {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
         u.arbitrary_iter()?.collect()
+    }
+
+    fn arbitrary_take_rest(u: Unstructured<'_>) -> Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
     }
 
     fn size_hint() -> (usize, Option<usize>) {
@@ -758,7 +790,7 @@ where
 
 impl Arbitrary for String {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-        let size = u.arbitrary_len::<char>()?;
+        let size = u.arbitrary_len::<u8>()?;
         (0..size)
             .map(|_| <char as Arbitrary>::arbitrary(u))
             .collect()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,14 +545,24 @@ macro_rules! arbitrary_tuple {
 arbitrary_tuple!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z);
 
 macro_rules! arbitrary_array {
-    {$n:expr, $t:ident $($ts:ident)*} => {
-        arbitrary_array!{($n - 1), $($ts)*}
+    {$n:expr, ($t:ident, $a:ident) $(($ts:ident, $as:ident))*} => {
+        arbitrary_array!{($n - 1), $(($ts, $as))*}
 
         impl<T: Arbitrary> Arbitrary for [T; $n] {
             fn arbitrary(u: &mut Unstructured<'_>) -> Result<[T; $n]> {
                 Ok([
                     Arbitrary::arbitrary(u)?,
                     $(<$ts as Arbitrary>::arbitrary(u)?),*
+                ])
+            }
+
+            #[allow(unused_mut)]
+            fn arbitrary_take_rest(mut u: Unstructured<'_>) -> Result<[T; $n]> {
+                $(let $as = $ts::arbitrary(&mut u)?;)*
+                let last = Arbitrary::arbitrary_take_rest(u)?;
+
+                Ok([
+                    $($as,)* last
                 ])
             }
 
@@ -591,7 +601,11 @@ macro_rules! arbitrary_array {
     ($n: expr,) => {};
 }
 
-arbitrary_array! { 32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T }
+arbitrary_array! { 32, (T, a) (T, b) (T, c) (T, d) (T, e) (T, f) (T, g) (T, h)
+(T, i) (T, j) (T, k) (T, l) (T, m) (T, n) (T, o) (T, p)
+(T, q) (T, r) (T, s) (T, u) (T, v) (T, w) (T, x) (T, y)
+(T, z) (T, aa) (T, ab) (T, ac) (T, ad) (T, ae) (T, af)
+(T, ag) }
 
 fn shrink_collection<'a, T, A: Arbitrary>(
     entries: impl Iterator<Item = T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1097,6 +1097,25 @@ mod test {
     }
 
     #[test]
+    fn arbitrary_collection() {
+        let x = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8,
+        ];
+        assert_eq!(
+            Vec::<u8>::arbitrary(&mut Unstructured::new(&x)).unwrap(),
+            &[1, 2, 3, 4, 5, 6, 7, 8]
+        );
+        assert_eq!(
+            Vec::<u32>::arbitrary(&mut Unstructured::new(&x)).unwrap(),
+            &[0x4030201, 0x8070605]
+        );
+        assert_eq!(
+            String::arbitrary(&mut Unstructured::new(&x)).unwrap(),
+            "\x01\x02\x03\x04\x05\x06\x07\x08"
+        );
+    }
+
+    #[test]
     fn arbitrary_take_rest() {
         let x = [1, 2, 3, 4];
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,15 @@ pub trait Arbitrary: Sized + 'static {
     /// See also the documentation for [`Unstructured`][crate::Unstructured].
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self>;
 
+    /// Generate an arbitrary value of `Self` from the entirety of the given unstructured data.
+    ///
+    /// This is similar to Arbitrary::arbitrary, however it assumes that it is the
+    /// last consumer of the given data, and is thus able to consume it all if it needs.
+    /// See also the documentation for [`Unstructured`][crate::Unstructured].
+    fn arbitrary_take_rest(mut u: Unstructured<'_>) -> Result<Self> {
+        Self::arbitrary(&mut u)
+    }
+
     /// Get a size hint for how many bytes out of an `Unstructured` this type
     /// needs to construct itself.
     ///

--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -399,11 +399,6 @@ impl<'a> Unstructured<'a> {
     ///
     /// Returns a slice of all the remaining, unconsumed bytes.
     ///
-    /// If the underlying data is already exhausted, returns an error.
-    ///
-    /// Any subsequent requests for bytes will fail afterwards, since the
-    /// underlying data will have already been exhausted.
-    ///
     /// # Example
     ///
     /// ```
@@ -411,17 +406,12 @@ impl<'a> Unstructured<'a> {
     ///
     /// let mut u = Unstructured::new(&[1, 2, 3]);
     ///
-    /// let mut remaining = u.take_rest()
-    ///     .expect("we know that `u` is non-empty, so `take_rest` cannot fail");
+    /// let mut remaining = u.take_rest();
     ///
     /// assert_eq!(remaining, [1, 2, 3]);
     /// ```
-    pub fn take_rest(&mut self) -> Result<&'a [u8]> {
-        if self.data.is_empty() {
-            Err(Error::NotEnoughData)
-        } else {
-            Ok(mem::replace(&mut self.data, &[]))
-        }
+    pub fn take_rest(mut self) -> &'a [u8] {
+        mem::replace(&mut self.data, &[])
     }
 }
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -54,6 +54,26 @@ fn tuple_struct() {
     assert_eq!((2, Some(2)), <MyTupleStruct as Arbitrary>::size_hint());
 }
 
+#[derive(Clone, Debug, Arbitrary)]
+struct EndingInVec(u8, bool, u32, Vec<u16>);
+#[derive(Clone, Debug, Arbitrary)]
+struct EndingInString(u8, bool, u32, String);
+
+#[test]
+fn test_take_rest() {
+    let bytes = [1, 1, 1, 2, 3, 4, 5, 6, 7, 8];
+    let s1 = EndingInVec::arbitrary_take_rest(Unstructured::new(&bytes)).unwrap();
+    let s2 = EndingInString::arbitrary_take_rest(Unstructured::new(&bytes)).unwrap();
+    assert_eq!(s1.0, 1);
+    assert_eq!(s2.0, 1);
+    assert_eq!(s1.1, true);
+    assert_eq!(s2.1, true);
+    assert_eq!(s1.2, 0x4030201);
+    assert_eq!(s2.2, 0x4030201);
+    assert_eq!(s1.3, vec![0x605, 0x807]);
+    assert_eq!(s2.3, "\x05\x06\x07\x08");
+}
+
 #[derive(Copy, Clone, Debug, Arbitrary)]
 enum MyEnum {
     Unit,


### PR DESCRIPTION
Fixes #17, fixes #18

<s>This does not migrate arrays and tuples over, but it handles everything else.</s>



r? @fitzgen