### PR TITLE
Add a `depth` parameter to `size_hint` to avoid infinite recursion

### DIFF
--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -1,7 +1,31 @@
 //! Utilities for working with and combining the results of
 //! [`Arbitrary::size_hint`][crate::Arbitrary::size_hint].
 
+/// Protects against potential infinite recursion when calculating size hints
+/// due to indirect type recursion.
+///
+/// When the depth is not too deep, calls `f` with `depth + 1` to calculate the
+/// size hint.
+///
+/// Otherwise, returns the default size hint: `(0, None)`.
+///
+/// See the [docs for `Arbitrary::shrink`][crate::Arbitrary::shrink] for example
+/// usage.
+#[inline]
+pub fn recursion_guard(
+    depth: usize,
+    f: impl FnOnce(usize) -> (usize, Option<usize>),
+) -> (usize, Option<usize>) {
+    const MAX_DEPTH: usize = 20;
+    if depth > MAX_DEPTH {
+        (0, None)
+    } else {
+        f(depth + 1)
+    }
+}
+
 /// Take the sum of the `lhs` and `rhs` size hints.
+#[inline]
 pub fn and(lhs: (usize, Option<usize>), rhs: (usize, Option<usize>)) -> (usize, Option<usize>) {
     let lower = lhs.0 + rhs.0;
     let upper = lhs.1.and_then(|lhs| rhs.1.map(|rhs| lhs + rhs));
@@ -12,13 +36,16 @@ pub fn and(lhs: (usize, Option<usize>), rhs: (usize, Option<usize>)) -> (usize, 
 ///
 /// If `hints` is empty, returns `(0, Some(0))`, aka the size of consuming
 /// nothing.
+#[inline]
 pub fn and_all(hints: &[(usize, Option<usize>)]) -> (usize, Option<usize>) {
     hints.iter().copied().fold((0, Some(0)), and)
 }
 
-/// Take the maximum of the `lhs` and `rhs` size hints.
+/// Take the minimum of the lower bounds and maximum of the upper bounds in the
+/// `lhs` and `rhs` size hints.
+#[inline]
 pub fn or(lhs: (usize, Option<usize>), rhs: (usize, Option<usize>)) -> (usize, Option<usize>) {
-    let lower = std::cmp::max(lhs.0, rhs.0);
+    let lower = std::cmp::min(lhs.0, rhs.0);
     let upper = lhs
         .1
         .and_then(|lhs| rhs.1.map(|rhs| std::cmp::max(lhs, rhs)));
@@ -29,8 +56,13 @@ pub fn or(lhs: (usize, Option<usize>), rhs: (usize, Option<usize>)) -> (usize, O
 ///
 /// If `hints` is empty, returns `(0, Some(0))`, aka the size of consuming
 /// nothing.
+#[inline]
 pub fn or_all(hints: &[(usize, Option<usize>)]) -> (usize, Option<usize>) {
-    hints.iter().copied().fold((0, Some(0)), or)
+    if let Some(head) = hints.first().copied() {
+        hints[1..].iter().copied().fold(head, or)
+    } else {
+        (0, Some(0))
+    }
 }
 
 #[cfg(test)]
@@ -45,10 +77,10 @@ mod tests {
 
     #[test]
     fn or() {
-        assert_eq!((3, Some(3)), super::or((2, Some(2)), (3, Some(3))));
-        assert_eq!((3, None), super::or((2, Some(2)), (3, None)));
-        assert_eq!((3, None), super::or((2, None), (3, Some(3))));
-        assert_eq!((3, None), super::or((2, None), (3, None)));
+        assert_eq!((2, Some(3)), super::or((2, Some(2)), (3, Some(3))));
+        assert_eq!((2, None), super::or((2, Some(2)), (3, None)));
+        assert_eq!((2, None), super::or((2, None), (3, Some(3))));
+        assert_eq!((2, None), super::or((2, None), (3, None)));
     }
 
     #[test]
@@ -76,19 +108,19 @@ mod tests {
     fn or_all() {
         assert_eq!((0, Some(0)), super::or_all(&[]));
         assert_eq!(
-            (4, Some(4)),
+            (1, Some(4)),
             super::or_all(&[(1, Some(1)), (2, Some(2)), (4, Some(4))])
         );
         assert_eq!(
-            (4, None),
+            (1, None),
             super::or_all(&[(1, Some(1)), (2, Some(2)), (4, None)])
         );
         assert_eq!(
-            (4, None),
+            (1, None),
             super::or_all(&[(1, Some(1)), (2, None), (4, Some(4))])
         );
         assert_eq!(
-            (4, None),
+            (1, None),
             super::or_all(&[(1, None), (2, Some(2)), (4, Some(4))])
         );
     }

--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -212,7 +212,7 @@ impl<'a> Unstructured<'a> {
         ElementType: Arbitrary,
     {
         let byte_size = self.arbitrary_byte_size()?;
-        let (lower, upper) = <ElementType as Arbitrary>::size_hint();
+        let (lower, upper) = <ElementType as Arbitrary>::size_hint(0);
         let elem_size = upper.unwrap_or_else(|| lower * 2);
         let elem_size = std::cmp::max(1, elem_size);
         Ok(byte_size / elem_size)
@@ -459,7 +459,7 @@ impl<'a> Unstructured<'a> {
     pub fn arbitrary_take_rest_iter<ElementType: Arbitrary>(
         self,
     ) -> Result<ArbitraryTakeRestIter<'a, ElementType>> {
-        let (lower, upper) = ElementType::size_hint();
+        let (lower, upper) = ElementType::size_hint(0);
 
         let elem_size = upper.unwrap_or(lower * 2);
         let elem_size = std::cmp::max(1, elem_size);

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -30,7 +30,7 @@ fn struct_with_named_fields() {
         ]
     );
 
-    assert_eq!((3, Some(3)), <Rgb as Arbitrary>::size_hint());
+    assert_eq!((3, Some(3)), <Rgb as Arbitrary>::size_hint(0));
 }
 
 #[derive(Copy, Clone, Debug, Arbitrary)]
@@ -51,7 +51,7 @@ fn tuple_struct() {
         assert_eq!(b, s.1);
     }
 
-    assert_eq!((2, Some(2)), <MyTupleStruct as Arbitrary>::size_hint());
+    assert_eq!((2, Some(2)), <MyTupleStruct as Arbitrary>::size_hint(0));
 }
 
 #[derive(Clone, Debug, Arbitrary)]
@@ -144,5 +144,27 @@ fn derive_enum() {
     assert!(saw_tuple);
     assert!(saw_struct);
 
-    assert_eq!((13, Some(13)), <MyEnum as Arbitrary>::size_hint());
+    assert_eq!((4, Some(17)), <MyEnum as Arbitrary>::size_hint(0));
+}
+
+#[derive(Arbitrary, Debug)]
+enum RecursiveTree {
+    Leaf,
+    Node {
+        left: Box<RecursiveTree>,
+        right: Box<RecursiveTree>,
+    },
+}
+
+#[test]
+fn recursive() {
+    let raw = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let _rec: RecursiveTree = arbitrary_from(&raw);
+
+    let (lower, upper) = <RecursiveTree as Arbitrary>::size_hint(0);
+    assert_eq!(lower, 4, "need a u32 for the discriminant at minimum");
+    assert!(
+        upper.is_none(),
+        "potentially infinitely recursive, so no upper bound"
+    );
 }


### PR DESCRIPTION
Note that the implementations of `size_hint` only need to increment the depth at indirection points where recursion can happen, e.g. at a `Box`. We take advantage of this in the impls for `std` types, but conservatively do not take advantage of that in the custom derive, since it doesn't have the necessary info.

Fixes #30