### PR TITLE
Bump to version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,41 @@ Released YYYY-MM-DD.
 
 --------------------------------------------------------------------------------
 
+## 0.4.0
+
+Released 2020-01-22.
+
+This is technically a breaking change, but we expect that nearly everyone should
+be able to upgrade without any compilation errors. The only exception is if you
+were implementing the `Arbitrary::size_hint` method by hand. If so, see the
+"changed" section below and the [API docs for
+`Arbitrary::shrink`](https://docs.rs/arbitrary/0.4.0/arbitrary/trait.Arbitrary.html#method.size_hint)
+for details.
+
+### Added
+
+* Added [the `arbitary::size_hint::recursion_guard` helper
+  function][recursion_guard] for guarding against infinite recursion in
+  `size_hint` implementations for recursive types.
+
+### Changed
+
+* The `Arbitrary::size_hint` signature now takes a `depth: usize`
+  parameter. This should be passed along unmodified to any nested calls of other
+  `size_hint` methods. If you're implementing `size_hint` for a recursive type
+  (like a linked list or tree) or a generic type with type parameters, you
+  should use [the new `arbitrary::size_hint::recursion_guard` helper
+  function][recursion_guard].
+
+### Fixed
+
+* Fixed infinite recursion in generated `size_hint` implementations
+  from `#[derive(Arbitrary)]` for recursive types.
+
+[recursion_guard]: https://docs.rs/arbitrary/0.4.0/arbitrary/size_hint/fn.recursion_guard.html
+
+--------------------------------------------------------------------------------
+
 ## 0.3.2
 
 Released 2020-01-16.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrary"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Simonas Kazlauskas <arbitrary@kazlauskas.me>", "Brian L. Troutwine <brian@troutwine.us>"]
 categories = ["development-tools::testing"]
 edition = "2018"
@@ -12,7 +12,7 @@ repository = "https://github.com/nagisa/rust_arbitrary/"
 documentation = "https://docs.rs/arbitrary/"
 
 [dependencies]
-derive_arbitrary = { version = "=0.3.3", path = "./derive", optional = true }
+derive_arbitrary = { version = "=0.4.0", path = "./derive", optional = true }
 
 [dev-dependencies]
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_arbitrary"
-version = "0.3.3" # Make sure it matches the version of the arbitrary crate itself.
+version = "0.4.0" # Make sure it matches the version of the arbitrary crate itself.
 authors = ["Andre Bogus <bogusandre@gmail.com>"]
 categories = ["development-tools::testing"]
 edition = "2018"


### PR DESCRIPTION
After we merge this, I'll send corresponding PRs to rust-fuzz/libfuzzer and cargo-fuzz.

The libfuzzer PR will also need to be a breaking version bump, but I think we can get away with cargo-fuzz being a point release. Sound good?