### PR TITLE
Remove need for `synstructure` dependency

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/arbitrary/"
 
 [dependencies]
 proc-macro2 = "1.0"
-syn = "1.0"
-synstructure = "0.12"
+quote = "1.0"
+syn = { version = "1.0", features = ['derive'] }
 
 [lib]
 proc_macro = true

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,154 +1,248 @@
-use proc_macro2::{Ident, Span, TokenStream};
-use synstructure::*;
+extern crate proc_macro;
 
-decl_derive!([Arbitrary] => arbitrary_derive);
+use proc_macro2::{Literal, TokenStream};
+use quote::quote;
+use syn::*;
 
-fn gen_arbitrary_method(variants: &[VariantInfo]) -> TokenStream {
-    if variants.len() == 1 {
-        // struct
-        let con = variants[0].construct(|_, _| quote! { Arbitrary::arbitrary(u)? });
-        let con_rest = construct_take_rest(&variants[0]);
-        quote! {
-            fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-                Ok(#con)
-            }
+#[proc_macro_derive(Arbitrary)]
+pub fn derive_arbitrary(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(tokens as syn::DeriveInput);
 
-            fn arbitrary_take_rest(mut u: Unstructured<'_>) -> Result<Self> {
-                Ok(#con_rest)
-            }
-        }
-    } else {
-        // enum
-        let mut variant_tokens = TokenStream::new();
-        let mut variant_tokens_take_rest = TokenStream::new();
-
-        for (count, variant) in variants.iter().enumerate() {
-            let count = count as u64;
-            let constructor = variant.construct(|_, _| quote! { Arbitrary::arbitrary(u)? });
-            variant_tokens.extend(quote! { #count => #constructor, });
-
-            let constructor_take_rest = construct_take_rest(&variant);
-            variant_tokens_take_rest.extend(quote! { #count => #constructor_take_rest, });
-        }
-
-        let count = variants.len() as u64;
-
-        quote! {
-            fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
-                // Use a multiply + shift to generate a ranged random number
-                // with slight bias. For details, see:
-                // https://lemire.me/blog/2016/06/30/fast-random-shuffling
-                Ok(match (u64::from(<u32 as Arbitrary>::arbitrary(u)?) * #count) >> 32 {
-                    #variant_tokens
-                    _ => unreachable!()
-                })
-            }
-
-            fn arbitrary_take_rest(mut u: Unstructured<'_>) -> Result<Self> {
-                // Use a multiply + shift to generate a ranged random number
-                // with slight bias. For details, see:
-                // https://lemire.me/blog/2016/06/30/fast-random-shuffling
-                Ok(match (u64::from(<u32 as Arbitrary>::arbitrary(&mut u)?) * #count) >> 32 {
-                    #variant_tokens_take_rest
-                    _ => unreachable!()
-                })
-            }
-        }
-    }
-}
-
-fn construct_take_rest(v: &VariantInfo) -> TokenStream {
-    let len = v.bindings().len();
-    v.construct(|_, idx| {
-        if idx == len - 1 {
-            quote! { Arbitrary::arbitrary_take_rest(u)? }
-        } else {
-            quote! { Arbitrary::arbitrary(&mut u)? }
-        }
-    })
-}
-
-fn gen_size_hint_method(s: &Structure) -> TokenStream {
-    let mut sizes = Vec::with_capacity(s.variants().len());
-    for v in s.variants().iter() {
-        let tys = v.ast().fields.iter().map(|f| &f.ty);
-        sizes.push(quote! {
-            arbitrary::size_hint::and_all(&[
-                #( <#tys as Arbitrary>::size_hint(depth) ),*
-            ])
-        });
-    }
-    if s.variants().len() > 1 {
-        // Need to add the discriminant's size for `enum`s.
-        quote! {
-            #[inline]
-            fn size_hint(depth: usize) -> (usize, Option<usize>) {
-                arbitrary::size_hint::and(
-                    <u32 as Arbitrary>::size_hint(depth),
-                    arbitrary::size_hint::recursion_guard(depth, |depth| {
-                        arbitrary::size_hint::or_all(&[ #( #sizes ),* ])
-                    }),
-                )
-            }
-        }
-    } else {
-        quote! {
-            #[inline]
-            fn size_hint(depth: usize) -> (usize, Option<usize>) {
-                arbitrary::size_hint::recursion_guard(depth, |depth| {
-                    arbitrary::size_hint::or_all(&[ #( #sizes ),* ])
-                })
-            }
-        }
-    }
-}
-
-fn gen_shrink_method(s: &Structure) -> TokenStream {
-    let variants = s.each_variant(|v| {
-        if v.bindings().is_empty() {
-            return quote! {
-                Box::new(None.into_iter())
-            };
-        }
-
-        let mut value_idents = vec![];
-        let mut shrinker_idents = vec![];
-        let mut shrinker_exprs = vec![];
-        for (i, b) in v.bindings().iter().enumerate() {
-            value_idents.push(Ident::new(&format!("value{}", i), Span::call_site()));
-            shrinker_idents.push(Ident::new(&format!("shrinker{}", i), Span::call_site()));
-            shrinker_exprs.push(quote! { Arbitrary::shrink(#b) });
-        }
-        let cons = v.construct(|_, i| &value_idents[i]);
-        let shrinker_idents = &shrinker_idents;
-        quote! {
-            #( let mut #shrinker_idents = #shrinker_exprs; )*
-            Box::new(std::iter::from_fn(move || {
-                #( let #value_idents = #shrinker_idents.next()?; )*
-                Some(#cons)
-            }))
-        }
-    });
-
-    quote! {
-        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-            match self {
-                #variants
-            }
-        }
-    }
-}
-
-fn arbitrary_derive(s: Structure) -> TokenStream {
-    let arbitrary_method = gen_arbitrary_method(s.variants());
-    let size_hint_method = gen_size_hint_method(&s);
-    let shrink_method = gen_shrink_method(&s);
-    s.gen_impl(quote! {
-        use arbitrary::{Arbitrary, Unstructured, Result};
-        gen impl Arbitrary for @Self {
+    let arbitrary_method = gen_arbitrary_method(&input);
+    let size_hint_method = gen_size_hint_method(&input);
+    let shrink_method = gen_shrink_method(&input);
+    let name = input.ident;
+    // Add a bound `T: Arbitrary` to every type parameter T.
+    let generics = add_trait_bounds(input.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    (quote! {
+        impl #impl_generics arbitrary::Arbitrary for #name #ty_generics #where_clause {
             #arbitrary_method
             #size_hint_method
             #shrink_method
         }
     })
+    .into()
+}
+
+// Add a bound `T: Arbitrary` to every type parameter T.
+fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in generics.params.iter_mut() {
+        if let GenericParam::Type(type_param) = param {
+            type_param.bounds.push(parse_quote!(arbitrary::Arbitrary));
+        }
+    }
+    generics
+}
+
+fn gen_arbitrary_method(input: &DeriveInput) -> TokenStream {
+    let ident = &input.ident;
+    let arbitrary_structlike = |fields| {
+        let arbitrary = construct(fields, |_, _| quote!(arbitrary::Arbitrary::arbitrary(u)?));
+        let arbitrary_take_rest = construct_take_rest(fields);
+        quote! {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                Ok(#ident #arbitrary)
+            }
+
+            fn arbitrary_take_rest(mut u: arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                Ok(#ident #arbitrary_take_rest)
+            }
+        }
+    };
+    match &input.data {
+        Data::Struct(data) => arbitrary_structlike(&data.fields),
+        Data::Union(data) => arbitrary_structlike(&Fields::Named(data.fields.clone())),
+        Data::Enum(data) => {
+            let variants = data.variants.iter().enumerate().map(|(i, variant)| {
+                let idx = i as u64;
+                let ctor = construct(&variant.fields, |_, _| {
+                    quote!(arbitrary::Arbitrary::arbitrary(u)?)
+                });
+                let variant_name = &variant.ident;
+                quote! { #idx => #ident::#variant_name #ctor }
+            });
+            let variants_take_rest = data.variants.iter().enumerate().map(|(i, variant)| {
+                let idx = i as u64;
+                let ctor = construct_take_rest(&variant.fields);
+                let variant_name = &variant.ident;
+                quote! { #idx => #ident::#variant_name #ctor }
+            });
+            let count = data.variants.len() as u64;
+            quote! {
+                fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                    // Use a multiply + shift to generate a ranged random number
+                    // with slight bias. For details, see:
+                    // https://lemire.me/blog/2016/06/30/fast-random-shuffling
+                    Ok(match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * #count) >> 32 {
+                        #(#variants,)*
+                        _ => unreachable!()
+                    })
+                }
+
+                fn arbitrary_take_rest(mut u: arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                    // Use a multiply + shift to generate a ranged random number
+                    // with slight bias. For details, see:
+                    // https://lemire.me/blog/2016/06/30/fast-random-shuffling
+                    Ok(match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(&mut u)?) * #count) >> 32 {
+                        #(#variants_take_rest,)*
+                        _ => unreachable!()
+                    })
+                }
+            }
+        }
+    }
+}
+
+fn construct(fields: &Fields, ctor: impl Fn(usize, &Field) -> TokenStream) -> TokenStream {
+    match fields {
+        Fields::Named(names) => {
+            let names = names.named.iter().enumerate().map(|(i, f)| {
+                let name = f.ident.as_ref().unwrap();
+                let ctor = ctor(i, f);
+                quote! { #name: #ctor }
+            });
+            quote! { { #(#names,)* } }
+        }
+        Fields::Unnamed(names) => {
+            let names = names.unnamed.iter().enumerate().map(|(i, f)| {
+                let ctor = ctor(i, f);
+                quote! { #ctor }
+            });
+            quote! { ( #(#names),* ) }
+        }
+        Fields::Unit => quote!(),
+    }
+}
+
+fn construct_take_rest(fields: &Fields) -> TokenStream {
+    construct(fields, |idx, _| {
+        if idx + 1 == fields.len() {
+            quote! { arbitrary::Arbitrary::arbitrary_take_rest(u)? }
+        } else {
+            quote! { arbitrary::Arbitrary::arbitrary(&mut u)? }
+        }
+    })
+}
+
+fn gen_size_hint_method(input: &DeriveInput) -> TokenStream {
+    let size_hint_fields = |fields: &Fields| {
+        let tys = fields.iter().map(|f| &f.ty);
+        quote! {
+            arbitrary::size_hint::and_all(&[
+                #( <#tys as Arbitrary>::size_hint(depth) ),*
+            ])
+        }
+    };
+    let size_hint_structlike = |fields: &Fields| {
+        let hint = size_hint_fields(fields);
+        quote! {
+            #[inline]
+            fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                arbitrary::size_hint::recursion_guard(depth, |depth| #hint)
+            }
+        }
+    };
+    match &input.data {
+        Data::Struct(data) => size_hint_structlike(&data.fields),
+        Data::Union(data) => size_hint_structlike(&Fields::Named(data.fields.clone())),
+        Data::Enum(data) => {
+            let variants = data.variants.iter().map(|v| size_hint_fields(&v.fields));
+            quote! {
+                #[inline]
+                fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                    arbitrary::size_hint::and(
+                        <u32 as Arbitrary>::size_hint(depth),
+                        arbitrary::size_hint::recursion_guard(depth, |depth| {
+                            arbitrary::size_hint::or_all(&[ #( #variants ),* ])
+                        }),
+                    )
+                }
+            }
+        }
+    }
+}
+
+fn gen_shrink_method(input: &DeriveInput) -> TokenStream {
+    let ident = &input.ident;
+    let shrink_structlike = |fields| {
+        let inner = shrink(&quote!(#ident), fields, |i, field| match &field.ident {
+            Some(i) => quote!(&self.#i),
+            None => {
+                let i = Literal::usize_unsuffixed(i);
+                quote!(&self.#i)
+            }
+        });
+        quote! {
+            fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+                #inner
+            }
+        }
+    };
+
+    return match &input.data {
+        Data::Struct(data) => shrink_structlike(&data.fields),
+        Data::Union(data) => shrink_structlike(&Fields::Named(data.fields.clone())),
+        Data::Enum(data) => {
+            let variants = data.variants.iter().map(|variant| {
+                let mut binding_names = Vec::new();
+                let bindings = match &variant.fields {
+                    Fields::Named(_) => {
+                        let names = variant.fields.iter().map(|f| {
+                            let name = f.ident.as_ref().unwrap();
+                            binding_names.push(quote!(#name));
+                            name
+                        });
+                        quote!({#(#names),*})
+                    }
+                    Fields::Unnamed(_) => {
+                        let names = (0..variant.fields.len()).map(|i| {
+                            let name = quote::format_ident!("f{}", i);
+                            binding_names.push(quote!(#name));
+                            name
+                        });
+                        quote!((#(#names),*))
+                    }
+                    Fields::Unit => quote!(),
+                };
+                let variant_name = &variant.ident;
+                let shrink = shrink(&quote!(#ident::#variant_name), &variant.fields, |i, _| {
+                    binding_names[i].clone()
+                });
+                quote!(#ident::#variant_name #bindings => { #shrink })
+            });
+            quote! {
+                fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+                    match self {
+                        #(#variants)*
+                    }
+                }
+            }
+        }
+    };
+
+    fn shrink(
+        prefix: &TokenStream,
+        fields: &Fields,
+        access_field: impl Fn(usize, &Field) -> TokenStream,
+    ) -> TokenStream {
+        if fields.len() == 0 {
+            return quote!(Box::new(None.into_iter()));
+        }
+        let iters = fields.iter().enumerate().map(|(i, f)| {
+            let name = quote::format_ident!("field{}", i);
+            let field = access_field(i, f);
+            quote! { let mut #name = arbitrary::Arbitrary::shrink(#field); }
+        });
+        let ctor = construct(fields, |i, _| {
+            let iter = quote::format_ident!("field{}", i);
+            quote!(#iter.next()?)
+        });
+        quote! {
+                #(#iters)*
+                Box::new(std::iter::from_fn(move || {
+                    Some(#prefix #ctor)
+                }))
+        }
+    }
 }


### PR DESCRIPTION
This dependency activates a number of features on `syn`, such as
`extra-traits`, which can cause excessive recompiles if `synstructure`
is part of some builds but not part of others. Especially for
`derive(Arbitrary)` it's often included in some builds (tests) but not
others (normal builds). By removing this dependency it should be a bit
speedier to build while also avoiding feature thrashing in normal builds.