### PR TITLE
Use `int_in_range` in `Duration`'s `Arbitrary` implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,7 +600,7 @@ impl Arbitrary for Duration {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
         Ok(Self::new(
             <u64 as Arbitrary>::arbitrary(u)?,
-            <u32 as Arbitrary>::arbitrary(u)? % 1_000_000_000,
+            u.int_in_range(0..=999_999_999)?,
         ))
     }
 


### PR DESCRIPTION
This is both faster than using modulo and doesn't skew the distribution.