### PR TITLE
Update documentation suggesting version 0.2.0 to 0.4

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ fn once<T: 'static>(val: T) -> Box<dyn Iterator<Item = T>> {
 ///
 /// ```toml
 /// [dependencies]
-/// arbitrary = { version = "0.2.0", features = ["derive"] }
+/// arbitrary = { version = "0.4", features = ["derive"] }
 /// ```
 ///
 /// Then, you add the `#[derive(Arbitrary)]` annotation to your `struct` or


### PR DESCRIPTION
The suggested line causes the error:

the package `your_package` depends on `arbitrary`, with features: `derive` but `arbitrary` does not have these features.

Changing it to suggestion to 0.4 fixes the issue for my project and matches the README.