### PR TITLE
Bump to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ Released YYYY-MM-DD.
 
 * TODO (or remove section if none)
 
+## 1.0.2
+
+Released 2021-08-25.
+
+### Added
+
+* `Arbitrary` impls for `HashMap`s and `HashSet`s with custom `Hasher`s [#87](https://github.com/rust-fuzz/arbitrary/pull/87)
+
+--------------------------------------------------------------------------------
+
 ## 1.0.1
 
 Released 2021-05-20.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrary"
-version = "1.0.1" # Make sure this matches the derive crate version
+version = "1.0.2" # Make sure this matches the derive crate version
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_arbitrary"
-version = "1.0.1" # Make sure it matches the version of the arbitrary crate itself.
+version = "1.0.2" # Make sure it matches the version of the arbitrary crate itself.
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",


### PR DESCRIPTION
Version bump to make `Arbitrary` impls for `HashMap`s and `HashSet`s with custom `Hasher`s available.