### PR TITLE
Support `Cow`s with arbitrary lifetimes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -801,7 +801,7 @@ impl<'a, A: Arbitrary<'a>> Arbitrary<'a> for VecDeque<A> {
     }
 }
 
-impl<'a, A> Arbitrary<'a> for Cow<'a, A>
+impl<'a, 'b, A> Arbitrary<'a> for Cow<'b, A>
 where
     A: ToOwned + ?Sized,
     <A as ToOwned>::Owned: Arbitrary<'a>,


### PR DESCRIPTION
Fixes #86.

Since the lifetime parameter of `Cow` is only for the borrowed variant, it is irrelevant for the `impl`. This also allows for `Cow<'static, str>` as can be seen when testing with the following code:
```rust


#[derive(Arbitrary)]
pub struct StaticCow {
    cow: Cow<'static, str>,
}

#[test]
fn static_cow() {
    // Last byte is used for length
    let raw: Vec<u8> = vec![97, 98, 99, 100, 3];
    let static_cow: StaticCow = arbitrary_from(&raw);
    assert_eq!(
        Cow::<'static, str>::Owned("abc".to_string()),
        static_cow.cow
    );

    let (lower, upper) = <StaticCow as Arbitrary>::size_hint(0);
    assert_eq!(lower, 8);
    assert_eq!(upper, None);
}
```
If desirable I can also add this test case to `tests/derive.rs` (which is also where `arbitrary_from` is taken from).