### PR TITLE
WIP: Revert mode fixes #44

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -81,7 +81,6 @@ fn gen_dearbitrary_method(input: &DeriveInput, lifetime: LifetimeDef) -> TokenSt
                 quote!(arbitrary::Arbitrary::dearbitrary(&self.#a))
             }
         });
-        //let dearbitrary_take_rest = construct_take_rest(fields);
         quote! {
             fn dearbitrary(&self) -> Vec<u8> {
                 let mut v: Vec<u8> = Vec::new();
@@ -144,7 +143,6 @@ fn cons2(fields: &Fields) -> TokenStream {
         Fields::Named(names) => {
             let names = names.named.iter().enumerate().map(|(i, f)| {
                 let name = f.ident.as_ref().unwrap();
-                //let ctor = ctor(i, f);
                 quote!(v.append(&mut arbitrary::Arbitrary::dearbitrary(#name)))
                 
             });
@@ -167,7 +165,6 @@ fn cons(fields: &Fields) -> TokenStream {
         Fields::Named(names) => {
             let names = names.named.iter().enumerate().map(|(_, f)| {
                 let name = f.ident.as_ref().unwrap();
-                //let ctor = ctor(i, f);
                 quote! { #name }
             });
             quote! { { #(#names,)* } }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -13,6 +13,7 @@ pub fn derive_arbitrary(tokens: proc_macro::TokenStream) -> proc_macro::TokenStr
         build_arbitrary_lifetime(input.generics.clone());
 
     let arbitrary_method = gen_arbitrary_method(&input, lifetime_without_bounds.clone());
+    let dearbitrary_method = gen_dearbitrary_method(&input, lifetime_without_bounds.clone());
     let size_hint_method = gen_size_hint_method(&input);
     let name = input.ident;
     // Add a bound `T: Arbitrary` to every type parameter T.
@@ -31,6 +32,7 @@ pub fn derive_arbitrary(tokens: proc_macro::TokenStream) -> proc_macro::TokenStr
     (quote! {
         impl #impl_generics arbitrary::Arbitrary<#lifetime_without_bounds> for #name #ty_generics #where_clause {
             #arbitrary_method
+            #dearbitrary_method
             #size_hint_method
         }
     })
@@ -65,6 +67,102 @@ fn add_trait_bounds(mut generics: Generics, lifetime: LifetimeDef) -> Generics {
         }
     }
     generics
+}
+
+fn gen_dearbitrary_method(input: &DeriveInput, lifetime: LifetimeDef) -> TokenStream {
+    let ident = &input.ident;
+    let dearbitrary_structlike = |fields: &syn::Fields| {
+        let dearbitrary = deconstruct(fields, |i, f| {
+            if f.ident.is_some() {
+                let n = &f.ident;
+                quote!(arbitrary::Arbitrary::dearbitrary(&self.#n))
+            } else {
+                let a = i;
+                quote!(arbitrary::Arbitrary::dearbitrary(&self.#a))
+            }
+        });
+        //let dearbitrary_take_rest = construct_take_rest(fields);
+        quote! {
+            fn dearbitrary(&self) -> Vec<u8> {
+                let mut v: Vec<u8> = Vec::new();
+                #dearbitrary
+                v
+            }
+        }
+    };
+    match &input.data {
+        Data::Struct(data) => dearbitrary_structlike(&data.fields),
+        Data::Union(data) => dearbitrary_structlike(&Fields::Named(data.fields.clone())),
+        Data::Enum(data) => {
+            let variants = data.variants.iter().enumerate().map(|(i, variant)| {
+                let idx = i as u64;
+                let ctor = cons(&variant.fields);
+                let variant_name = &variant.ident;
+                quote! { #ident::#variant_name #ctor => #idx }
+            });
+
+            let count = data.variants.len() as u64;
+            quote! {
+                fn dearbitrary(&self) -> Vec<u8> {
+                    // Use a multiply + shift to generate a ranged random number
+                    // with slight bias. For details, see:
+                    // https://lemire.me/blog/2016/06/30/fast-random-shuffling
+                    let mut v = Vec::new();
+                    //x = (u64(xu32) * #count) >> 32
+                    
+                    let val = match self {
+                        #(#variants,)*
+                        _ => unreachable!()
+                    };
+                    let x = ((val << 32) / #count ) as u32;
+                    v.append(&mut x.to_le_bytes().to_vec());
+                    v.append(&mut arbitrary::Arbitrary::dearbitrary(self));
+                    v
+                }
+            }
+        }
+    }
+}
+
+fn cons(fields: &Fields) -> TokenStream {
+    match fields {
+        Fields::Named(names) => {
+            let names = names.named.iter().enumerate().map(|(i, f)| {
+                let name = f.ident.as_ref().unwrap();
+                //let ctor = ctor(i, f);
+                quote! { #name }
+            });
+            quote! { { #(#names,)* } }
+        }
+        Fields::Unnamed(names) => {
+            let names = names.unnamed.iter().enumerate().map(|(i, f)| {
+                quote! { _ }
+            });
+            quote! { ( #(#names),* ) }
+        }
+        Fields::Unit => quote!(),
+    }
+}
+
+fn deconstruct(fields: &Fields, ctor: impl Fn(usize, &Field) -> TokenStream) -> TokenStream {
+    match fields {
+        Fields::Named(names) => {
+            let names = names.named.iter().enumerate().map(|(i, f)| {
+                let name = f.ident.as_ref().unwrap();
+                let ctor = ctor(i, f);
+                quote! { v.append(&mut #ctor) }
+            });
+            quote! { { #(#names;)* } }
+        }
+        Fields::Unnamed(names) => {
+            let names = names.unnamed.iter().enumerate().map(|(i, f)| {
+                let ctor = ctor(i, f);                
+                quote! { v.append(&mut #ctor) }
+            });
+            quote! { { #(#names;)* } }
+        }
+        Fields::Unit => quote!(),
+    }
 }
 
 fn gen_arbitrary_method(input: &DeriveInput, lifetime: LifetimeDef) -> TokenStream {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -165,7 +165,7 @@ fn cons2(fields: &Fields) -> TokenStream {
 fn cons(fields: &Fields) -> TokenStream {
     match fields {
         Fields::Named(names) => {
-            let names = names.named.iter().enumerate().map(|(i, f)| {
+            let names = names.named.iter().enumerate().map(|(_, f)| {
                 let name = f.ident.as_ref().unwrap();
                 //let ctor = ctor(i, f);
                 quote! { #name }
@@ -173,7 +173,7 @@ fn cons(fields: &Fields) -> TokenStream {
             quote! { { #(#names,)* } }
         }
         Fields::Unnamed(names) => {
-            let names = names.unnamed.iter().enumerate().map(|(i, f)| {
+            let names = names.unnamed.iter().enumerate().map(|(i, _)| {
                 let id = Ident::new(&format!("x{}", i), Span::call_site());;
                 quote! { #id }
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1077,13 +1077,16 @@ impl<'a, A: Arbitrary<'a>> Arbitrary<'a> for Box<A> {
     }
 }
 
-impl<'a, A: Arbitrary<'a>> Arbitrary<'a> for Box<[A]> {
+impl<'a, A: Arbitrary<'a> + Clone> Arbitrary<'a> for Box<[A]> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         <Vec<A> as Arbitrary>::arbitrary(u).map(|x| x.into_boxed_slice())
     }
 
     fn dearbitrary(&self) -> Vec<u8> {
-        unimplemented!()
+        // for x in self.iter() {
+        //     v.push(*x.clone());
+        // }
+        <Vec<A> as Arbitrary>::dearbitrary(&self.to_vec())
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,7 +795,7 @@ impl<'a> Arbitrary<'a> for &'a [u8] {
         };
 
         let mut v = Vec::new();
-        v.append(&mut self.to_vec().clone());
+        v.append(&mut self.to_vec());
         v.append(&mut len_bytes);
         v
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,9 @@ pub trait Arbitrary<'a>: Sized {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self>;
 
     
-    /// reverts the progress of Arbitrary::arbitrary
+    /// Inverse operation of `arbitrary` aka creating the byte stream, which can be used
+    /// together with an `arbitrary` call to recreate `Self`.
+    /// 
     fn dearbitrary(&self) -> Vec<u8>;
 
     /// Generate an arbitrary value of `Self` from the entirety of the given unstructured data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ impl<'a> Arbitrary<'a> for () {
     }
 
     fn dearbitrary(&self) -> Vec<u8> {
-        unimplemented!()
+        Vec::new()
     }
 
     #[inline]
@@ -367,7 +367,7 @@ macro_rules! impl_arbitrary_for_floats {
                 }
 
                 fn dearbitrary(&self) -> Vec<u8> {
-                    unimplemented!()
+                    <$unsigned>::dearbitrary(&Self::to_bits(*self))
                 }
 
                 #[inline]
@@ -403,7 +403,7 @@ impl<'a> Arbitrary<'a> for char {
     }
 
     fn dearbitrary(&self) -> Vec<u8> {
-        unimplemented!()
+        u32::dearbitrary(&(*self as u32))
     }
 
     #[inline]

--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -207,6 +207,10 @@ impl<'a> Unstructured<'a> {
     ///
     ///         Ok(my_collection)
     ///     }
+    /// 
+    ///     fn dearbitrary(&self) -> Vec<u8> {
+    ///         unimplemented!()
+    ///     }
     /// }
     /// ```
     pub fn arbitrary_len<ElementType>(&mut self) -> Result<usize>

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -24,6 +24,14 @@ fn struct_with_named_fields() {
     assert_eq!((3, Some(3)), <Rgb as Arbitrary>::size_hint(0));
 }
 
+#[test]
+fn dearbitrary_struct_with_named_fields() {
+    let rgb = Rgb { r: 4, g: 5, b: 6 };
+    let expected = vec![4, 5, 6];
+    let actual = Rgb::dearbitrary(&rgb);
+    assert_eq!(expected, actual);
+}
+
 #[derive(Copy, Clone, Debug, Arbitrary)]
 struct MyTupleStruct(u8, bool);
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -68,11 +68,42 @@ fn test_take_rest() {
     assert_eq!(s2.3, "\x05\x06\x07\x08");
 }
 
-#[derive(Copy, Clone, Debug, Arbitrary)]
+#[derive(Copy, Clone, Debug, Arbitrary, PartialEq)]
 enum MyEnum {
     Unit,
     Tuple(u8, u16),
     Struct { a: u32, b: (bool, u64) },
+}
+
+#[test]
+fn dearbitrary_enum() {
+    let x = MyEnum::Unit;
+    let expected = vec![0, 0, 0, 0];
+    let actual = MyEnum::dearbitrary(&x);
+    assert_eq!(actual, expected);
+    let mut buf = Unstructured::new(&expected);
+    let actual2 = MyEnum::arbitrary(&mut buf).unwrap();
+    assert_eq!(actual2, x);
+
+    let x = MyEnum::Tuple(1, 2);
+    let expected = vec![86, 85, 85, 85, 1, 2, 0];
+    let actual = MyEnum::dearbitrary(&x);
+    assert_eq!(actual, expected);
+
+
+    let mut buf = Unstructured::new(&expected);
+    let actual2 = MyEnum::arbitrary(&mut buf).unwrap();
+    assert_eq!(actual2, x);
+
+
+    let x =  MyEnum::Struct { a: 157, b: (true, 1) };
+    let expected = vec![171, 170, 170, 170, 157, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+    let actual = MyEnum::dearbitrary(&x);
+    assert_eq!(actual, expected);
+
+    let mut buf = Unstructured::new(&expected);
+    let actual2 = MyEnum::arbitrary(&mut buf).unwrap();
+    assert_eq!(actual2, x);
 }
 
 #[test]


### PR DESCRIPTION
This PR solves issue #44 by implementing a `dearbitrary` function to create a byte buf, which can be used again with `arbitrary` to recreate the struct. It is not a one to one mapping, as e.g. bools only use the last bit of a byte value.

What works:
* [x] derive
* [x] integer/float/char/bools primitive types
* [x] tuples
* [x] `()`
* [ ] AtomicBool
* [ ] AtomicIsize
* [ ] AtomicUsize
* [ ] Ranges
* [ ] Duration
* [ ] Option<A>
* [ ] Result
* [ ] [T; N]
* [x] &'a [u8]
* [x] Vec
* [ ] BTreeMap
* [ ] BTreeSet
* [ ] BinaryHeap
* [ ] HashMap
* [ ] HashSet
* [ ] ... everything which uses an iterator
* [ ] &'a str
* [ ] String
* [x] Box<A>
* [x] Box<[A]>
* [ ] ... many other things missing

Many parts are missing, as I do not need them at the moment and have no time to implement them...

Remark: commits are prone to change/squashing/reordering!!