### PR TITLE
fix(Unstructured)!: don't produce meaningless data if exhausted

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1166,7 +1166,7 @@ mod test {
 
     #[test]
     fn finite_buffer_fill_buffer() {
-        let x = [1, 2, 3, 4];
+        let x = [1, 2, 3, 4, 5];
         let mut rb = Unstructured::new(&x);
         let mut z = [0; 2];
         rb.fill_buffer(&mut z).unwrap();
@@ -1174,7 +1174,9 @@ mod test {
         rb.fill_buffer(&mut z).unwrap();
         assert_eq!(z, [3, 4]);
         rb.fill_buffer(&mut z).unwrap();
-        assert_eq!(z, [0, 0]);
+        assert_eq!(z, [5, 0]);
+
+        assert!(rb.fill_buffer(&mut z).is_err());
     }
 
     #[test]

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -135,6 +135,17 @@ fn recursive() {
     );
 }
 
+#[test]
+fn recursive_first_variant() {
+    #[derive(PartialEq, Eq, Debug, Arbitrary)]
+    enum Nat {
+        Succ(Box<Nat>),
+        Zero,
+    }
+
+    assert!(Nat::arbitrary(&mut Unstructured::new(&[])).is_err());
+}
+
 #[derive(Arbitrary, Debug)]
 struct Generic<T> {
     inner: T,


### PR DESCRIPTION
If the `Unstructured` is completely exhausted, returning a buffer completely filled with zeroes instead of indicating failure does not
make sense. It also causes issues for any users of `Arbitrary` implementations for integers (which are based on this method) who rely on eventually getting a nonzero result to e.g. break recursion.

Fixes #107.