### PR TITLE
fix rust-analyzer incorrect-ident-case diagnostic

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -36,6 +36,7 @@ pub fn derive_arbitrary(tokens: proc_macro::TokenStream) -> proc_macro::TokenStr
 
     (quote! {
         thread_local! {
+            #[allow(non_upper_case_globals)]
             static #recursive_count: std::cell::Cell<u32> = std::cell::Cell::new(0);
         }
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "derive")]
-
 // Various structs/fields that we are deriving `Arbitrary` for aren't actually
 // used except to exercise the derive.
 #![allow(dead_code)]

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "derive")]
-
 // Various structs/fields that we are deriving `Arbitrary` for aren't actually
 // used except to show off the derive.
 #![allow(dead_code)]


### PR DESCRIPTION
Using the derive macro in a project with rust-analyzer gives an error complaining that this generated code isn't in the SCREAMING_SNAKE_CASE form. This change makes this diagnostic message go away.

The exact output of `rust-analyzer`:

```text
processing crate: playground, module: /home/charles/science/rust/playground/src/main.rs
Diagnostic { code: DiagnosticCode("incorrect-ident-case"), message: "Constant `RECURSIVE_COUNT_CustomThing` should have UPPER_SNAKE_CASE name, e.g. `RECURSIVE_COUNT_CUSTOM_THING`", range: 959..979, severity: WeakWarning, unused: false, experimental: false, fixes: None }

diagnostic scan complete
```