### PR TITLE
Improve derived recursion guard

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -35,15 +35,17 @@ pub fn derive_arbitrary(tokens: proc_macro::TokenStream) -> proc_macro::TokenStr
     let (_, ty_generics, where_clause) = generics.split_for_impl();
 
     (quote! {
-        thread_local! {
-            #[allow(non_upper_case_globals)]
-            static #recursive_count: std::cell::Cell<u32> = std::cell::Cell::new(0);
-        }
+        const _: () = {
+            thread_local! {
+                #[allow(non_upper_case_globals)]
+                static #recursive_count: std::cell::Cell<u32> = std::cell::Cell::new(0);
+            }
 
-        impl #impl_generics arbitrary::Arbitrary<#lifetime_without_bounds> for #name #ty_generics #where_clause {
-            #arbitrary_method
-            #size_hint_method
-        }
+            impl #impl_generics arbitrary::Arbitrary<#lifetime_without_bounds> for #name #ty_generics #where_clause {
+                #arbitrary_method
+                #size_hint_method
+            }
+        };
     })
     .into()
 }


### PR DESCRIPTION
[As per your invitation](https://github.com/rust-fuzz/arbitrary/pull/109#discussion_r898482854).

Turns
```rust
fn arbitrary(u: &mut Unstructured) -> Result<Self> {
    RECURSIVE_COUNT_Nah.with(|count| {
        if count.get() > 0 && u.is_empty() {
            return Err(arbitrary::Error::NotEnoughData);
        }
        count.set(count.get() + 1);
        let result = {
            Ok(
                match (u64::from(<u32 as Arbitrary>::arbitrary(u)?) * 2u64) >> 32 {
                    0u64 => Nah::Foo(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?),
                    1u64 => Nah::Bar(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?),
                    _ => panic!("internal error: entered unreachable code"),
                },
            )
        };
        count.set(count.get() - 1);
        result
    })
}
```
into
```rust
fn arbitrary(u: &mut Unstructured<'arbitrary>) -> Result<Self> {                                                                                                          
    let guard_against_recursion = u.is_empty();                                                                      
    if guard_against_recursion {                                                                                                   
        RECURSIVE_COUNT_Nah.with(|count| {                                                                                                      
            if count.get() > 0 {                                                                                                                               
                return Err(arbitrary::Error::NotEnoughData);       
            }                                                                                                                 
            count.set(count.get() + 1);                                                                                                      
            Ok(())                                                                                                                                          
        })?;                                                                                                                                                               
    }                                                                                                                      
    let result = (|| {                                                                                                                    
        Ok(                                                                                                                                              
            match (u64::from(<u32 as Arbitrary>::arbitrary(u)?) * 2u64) >> 32 {                                                                                         
                0u64 => Nah::Foo(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?),         
                1u64 => Nah::Bar(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?),                                                  
                _ => ::core::panicking::panic("internal error: entered unreachable code"),                                                          
            },                                                                                                                                                     
        )                                                                                                          
    })();                                                                                                                         
    if guard_against_recursion {                                                                                                                 
        RECURSIVE_COUNT_Nah.with(|count| {                                                                                                                    
            count.set(count.get() - 1);        
        });                                                                                                                  
    }                                                                                                                                       
    result                                                                                                                                                 
}     
```


I've also wrapped the thread local and impl in a `const _: () = {…};` to avoid name clashes. I have no idea whether that's the best way of doing it, but it's what serde does.