### PR TITLE
Use fewer input bytes for arbitrary_loop

### DIFF
--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -674,20 +674,8 @@ impl<'a> Unstructured<'a> {
     ) -> Result<()> {
         let min = min.unwrap_or(0);
         let max = max.unwrap_or(u32::MAX);
-        assert!(min <= max);
 
-        for _ in 0..min {
-            match f(self)? {
-                ControlFlow::Continue(_) => continue,
-                ControlFlow::Break(_) => return Ok(()),
-            }
-        }
-
-        for _ in 0..(max - min) {
-            let keep_going = self.arbitrary().unwrap_or(false);
-            if !keep_going {
-                break;
-            }
+        for _ in 0..self.int_in_range(min..=max)? {
             match f(self)? {
                 ControlFlow::Continue(_) => continue,
                 ControlFlow::Break(_) => break,


### PR DESCRIPTION
Asking for an arbitrary bool to decide whether the loop should keep going consumes a byte per loop iteration, while calling `int_in_range` instead consumes at most four bytes for any combination of arguments, and often less.

I'm trying to develop an intuition for what helps or hinders libFuzzer when driving a fuzz target that uses `arbitrary`, but I don't know enough. Do you suppose this is likely to work better? Do you have any advice on how to reason about questions like this?

I've been thinking about a `bounded_arbitrary_len` (or `arbitrary_bounded_len`? `arbitrary_len_in_range`?) that takes optional min/max bounds like `arbitrary_loop` does, but takes bytes from the end like `arbitrary_len` does. That similarly could consume fewer bytes than just calling `arbitrary_len` and clamping the result. Is that likely to help a fuzzer explore the state space more effectively?