### PR TITLE
Added a rust-version entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrary"
-version = "1.1.6" # Make sure this matches the derive crate version
+version = "1.1.7" # Make sure this matches the derive crate version
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",
@@ -17,6 +17,7 @@ description = "The trait for generating structured data from unstructured data"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-fuzz/arbitrary/"
 documentation = "https://docs.rs/arbitrary/"
+rust-version = "1.63.0"
 
 [dependencies]
 derive_arbitrary = { version = "1.1.6", path = "./derive", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_arbitrary"
-version = "1.1.6" # Make sure it matches the version of the arbitrary crate itself.
+version = "1.1.7" # Make sure it matches the version of the arbitrary crate itself.
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",
@@ -16,6 +16,7 @@ description = "Derives arbitrary traits"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-fuzz/arbitrary"
 documentation = "https://docs.rs/arbitrary/"
+rust-version = "1.63.0"
 
 [dependencies]
 proc-macro2 = "1.0"


### PR DESCRIPTION
Your crate doesn't specifiy a minimum rust version. However you are using a rather new core library feature (`core::array::from_fn`). This should be specified.

I also bumped your versions with this addition. Although this is a very difficult case. The introduction of from_fn could already be considered breaking semver.