### PR TITLE
Sync up `arbitrary` and `derive_arbitrary` versions; bump to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ Released YYYY-MM-DD.
 
 --------------------------------------------------------------------------------
 
+## 1.2.2
+
+Released 2023-01-03.
+
+### Fixed
+
+* Ensured that `arbitrary` and `derive_arbitrary` versions are synced up so that
+  they don't, e.g., emit generated code that depends on newer versions of
+  `arbitrary` than the one currently in
+  use. [#134](https://github.com/rust-fuzz/arbitrary/issues/134)
+
+## 1.2.1
+
+### Fixed
+
+* Fixed an issue where `std::thread_local!` macro invocations in derive code
+  were not fully prefixed, causing confusing build errors in certain situations.
+
 ## 1.2.0
 
 Released 2022-10-20.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrary"
-version = "1.2.0" # Make sure this matches the derive crate version (not including the patch version)
+version = "1.2.2" # Make sure this matches the derive crate version (not including the patch version)
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",
@@ -20,7 +20,7 @@ documentation = "https://docs.rs/arbitrary/"
 rust-version = "1.63.0"
 
 [dependencies]
-derive_arbitrary = { version = "1.1.6", path = "./derive", optional = true }
+derive_arbitrary = { version = "1.2.2", path = "./derive", optional = true }
 
 [features]
 # Turn this feature on to enable support for `#[derive(Arbitrary)]`.

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_arbitrary"
-version = "1.2.1" # Make sure it matches the version of the arbitrary crate itself (not including the patch version)
+version = "1.2.2" # Make sure it matches the version of the arbitrary crate itself (not including the patch version)
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",


### PR DESCRIPTION
Fixes #134