### PR TITLE
Allow trait bounds to be manually specified

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.63.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ['derive'] }
+darling = "0.14.2"
 
 [lib]
 proc_macro = true

--- a/derive/src/container_attributes.rs
+++ b/derive/src/container_attributes.rs
@@ -1,0 +1,9 @@
+use darling::FromDeriveInput;
+use syn::{punctuated::Punctuated, Token, TypeParam};
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(arbitrary))]
+pub struct ContainerAttributes {
+    #[darling(default)]
+    pub bound: Option<Punctuated<TypeParam, Token![,]>>,
+}

--- a/tests/bound.rs
+++ b/tests/bound.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "derive")]
+
+use arbitrary::{Arbitrary, Unstructured};
+
+fn arbitrary_from<'a, T: Arbitrary<'a>>(input: &'a [u8]) -> T {
+    let mut buf = Unstructured::new(input);
+    T::arbitrary(&mut buf).expect("can create arbitrary instance OK")
+}
+
+/// This wrapper trait *implies* `Arbitrary`, but the compiler isn't smart enough to work that out
+/// so when using this wrapper we *must* opt-out of the auto-generated `T: Arbitrary` bounds.
+pub trait WrapperTrait: for<'a> Arbitrary<'a> {}
+
+impl WrapperTrait for u32 {}
+
+#[derive(Arbitrary)]
+#[arbitrary(bound = "T: WrapperTrait")]
+struct GenericSingleBound<T: WrapperTrait> {
+    t: T,
+}
+
+#[test]
+fn single_bound() {
+    let v: GenericSingleBound<u32> = arbitrary_from(&[0, 0, 0, 0]);
+    assert_eq!(v.t, 0);
+}
+
+#[derive(Arbitrary)]
+#[arbitrary(bound = "T: WrapperTrait, U: WrapperTrait")]
+struct GenericMultipleBounds<T: WrapperTrait, U: WrapperTrait> {
+    t: T,
+    u: U,
+}
+
+#[test]
+fn multiple_bounds() {
+    let v: GenericMultipleBounds<u32, u32> = arbitrary_from(&[1, 0, 0, 0, 2, 0, 0, 0]);
+    assert_eq!(v.t, 1);
+    assert_eq!(v.u, 2);
+}


### PR DESCRIPTION
While working with some generic types I found that the `T: Arbitrary` bounds added by `arbitrary_derive` were too restrictive.

Consider a trait that requires `Arbitrary`, like this:

```rust
pub trait WrapperTrait: for<'a> Arbitrary<'a> {}
```

And a struct that uses it:

```rust
#[derive(Arbitrary)]
struct GenericSingleBound<T: WrapperTrait> {
    t: T,
}
```

The derive macro currently generates an impl like:

```rust
impl<'arbitrary, T: WrapperTrait + Arbitrary<'arbitrary>> Arbitrary<'arbitrary> for GenericSingleBound<T> {
    // ...
}
```

Even though `WrapperTrait` already implies `Arbitrary<'arbitrary>` via the universal lifetime quantifier, the compiler doesn't seem to be smart enough to work out that the bound is redundant. We get an error like this:

```
error[E0283]: type annotations needed: cannot satisfy `T: Arbitrary<'arbitrary>`
  --> tests/bound.rs:16:10
   |
16 | #[derive(Arbitrary)]
   |          ^^^^^^^^^
   |
   = note: cannot satisfy `T: Arbitrary<'arbitrary>`
   = note: this error originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Taking a leaf out of [`serde`'s book](https://serde.rs/container-attrs.html#bound), this PR adds a `bound = ".."` container attribute which allows manually overriding the inferred bound. In our example `arbitrary(bound = "T: WrapperTrait")` works as expected. See the test case in `./tests/bound.rs`.

## Implementation notes

- I've added a dependency on `darling` as I find it much easier to write proc macro code with it. I could switch to vanilla `syn` (or another macro crate) if you would prefer not to depend on `darling`.
- If a subset of types have bounds declared with `bound` then the omitted types will have their bounds from the type declaration dropped. This mimics `serde`.
- Bounds for irrelevant types are silently ignored, I'm not sure if we should raise an error for them instead. E.g. currently you can `bound = "T: Foo"` on a type with no generics.
- I'm a little unsure of how to handle the `attributes` field of [`TypeParam`](https://docs.rs/syn/latest/syn/struct.TypeParam.html). I figured that replacing the full `TypeParam` gives the most flexibility (even if it means duplicating attributes from the type declaration).