### PR TITLE
derive: add #[automatically_derived]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ Released YYYY-MM-DD.
 
 --------------------------------------------------------------------------------
 
+## 1.2.3
+
+Released 2023-01-20.
+
+### Fixed
+
+* The `derive(Arbitrary)` will now annotate the generated `impl`s with a `#[automatically_derived]`
+  attribute to indicate to e.g. clippy that lints should not fire for the code within the derived
+  implementation.
+
 ## 1.2.2
 
 Released 2023-01-03.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrary"
-version = "1.2.2" # Make sure this matches the derive crate version (not including the patch version)
+version = "1.2.3" # Make sure this matches the derive crate version (not including the patch version)
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",
@@ -20,7 +20,7 @@ documentation = "https://docs.rs/arbitrary/"
 rust-version = "1.63.0"
 
 [dependencies]
-derive_arbitrary = { version = "1.2.2", path = "./derive", optional = true }
+derive_arbitrary = { version = "1.2.3", path = "./derive", optional = true }
 
 [features]
 # Turn this feature on to enable support for `#[derive(Arbitrary)]`.

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_arbitrary"
-version = "1.2.2" # Make sure it matches the version of the arbitrary crate itself (not including the patch version)
+version = "1.2.3" # Make sure it matches the version of the arbitrary crate itself (not including the patch version)
 authors = [
     "The Rust-Fuzz Project Developers",
     "Nick Fitzgerald <fitzgen@gmail.com>",

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -50,6 +50,7 @@ fn expand_derive_arbitrary(input: syn::DeriveInput) -> Result<TokenStream> {
                 static #recursive_count: std::cell::Cell<u32> = std::cell::Cell::new(0);
             }
 
+            #[automatically_derived]
             impl #impl_generics arbitrary::Arbitrary<#lifetime_without_bounds> for #name #ty_generics #where_clause {
                 #arbitrary_method
                 #size_hint_method


### PR DESCRIPTION
Lack of this can trigger lints in `clippy` such as https://github.com/rust-lang/rust-clippy/issues/10185 with no obvious way to allow this lint for the generated impl specifically.

It is a good style and hygiene to add this attribute anyhhow.