### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ jobs:
     name: Vanilla Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - run: rustup update
     - name: Build
       run: cargo build --verbose --all
@@ -17,7 +17,7 @@ jobs:
     name: All Features Enabled Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - run: rustup update
     - name: Build
       run: cargo build --verbose --all-features --all
@@ -29,7 +29,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - run: rustup update
     - run: rustup component add clippy
     - run: cargo clippy --all-features --workspace -- -Dclippy::all
@@ -37,7 +37,7 @@ jobs:
     name: Check rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - run: rustup update
     - run: rustup component add rustfmt --toolchain stable
     - run: cargo +stable fmt --all -- --check
@@ -45,7 +45,7 @@ jobs:
     name: Run `int_in_range` fuzz target
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - run: rustup update
     - name: "Install nightly"
       run: rustup toolchain install nightly && rustup default nightly


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16
> ## v2.3.1
> 
> - Fix default branch resolution for .wiki and when using SSH
> 
> ## v2.3.0
> 
> - Fallback to the default branch
> 
> ## v2.2.0
> 
> - Fetch all history for all tags and branches when fetch-depth=0
> 
> ## v2.1.1
> 
> - Changes to support GHES
> 
> ## v2.1.0
> 
> - Group output
> - Changes to support GHES alpha release
> - Persist core.sshCommand for submodules
> - Add support ssh
> - Convert submodule SSH URL to HTTPS, when not using SSH
> - Add submodule support
> - Follow proxy settings
> - Fix ref for pr closed event when a pr is merged
> - Fix issue checking detached when git less than 2.22
> 
> ## v2.0.0
> 
> - Do not pass cred on command line
> - Add input persist-credentials
> - Fallback to REST API to download repo

As far as I can tell this should all be backwards compatible, so I do not expect any breakage.