### PR TITLE
fix(derive): uniformize imports of items defined in core

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -55,9 +55,9 @@ fn expand_derive_arbitrary(input: syn::DeriveInput) -> Result<TokenStream> {
 
     Ok(quote! {
         const _: () = {
-            std::thread_local! {
+            ::std::thread_local! {
                 #[allow(non_upper_case_globals)]
-                static #recursive_count: std::cell::Cell<u32> = std::cell::Cell::new(0);
+                static #recursive_count: ::core::cell::Cell<u32> = ::core::cell::Cell::new(0);
             }
 
             #[automatically_derived]


### PR DESCRIPTION
This uniformizes all `use std` which could be `use core` in code derived by `Arbitrary` macro.
This is already done at [this place](https://github.com/rust-fuzz/arbitrary/blob/2a0077fe50492dfe9f73574dc55fa483db963ec0/derive/src/lib.rs#L347).
It’s typically not a problem because `std` is required anyway for the derived code (because of `thread_local`), but [conflict with a Clippy lint](https://github.com/rust-lang/rust-clippy/issues/11970) (although this is likely a bug on clippy side?).