### PR TITLE
Derive `Debug` for `Unstructured`

### DIFF
--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -68,6 +68,7 @@ use std::{mem, ops};
 /// }
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct Unstructured<'a> {
     data: &'a [u8],
 }


### PR DESCRIPTION
The [C-DEBUG](https://rust-lang.github.io/api-guidelines/debuggability.html#all-public-types-implement-debug-c-debug) API guideline states: "All public types implement Debug; If there are exceptions, they are rare."

Unless there is good reason not to, `Unstructured` should implement `Debug`.