### PR TITLE
Widen implementation of `Arbitrary` for `PhantomData<A>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1097,7 +1097,7 @@ impl<'a, A: Arbitrary<'a>> Arbitrary<'a> for iter::Empty<A> {
     }
 }
 
-impl<'a, A: Arbitrary<'a>> Arbitrary<'a> for ::std::marker::PhantomData<A> {
+impl<'a, A: ?Sized> Arbitrary<'a> for ::std::marker::PhantomData<A> {
     fn arbitrary(_: &mut Unstructured<'a>) -> Result<Self> {
         Ok(::std::marker::PhantomData)
     }


### PR DESCRIPTION
Implements `Arbitrary` for `PhantomData<A>` where `A` is `?Sized`. Removes the requirement for `A` to implement `Arbitrary`.

Closes #137.