### PR TITLE
Fix `Vec` initialization in test

### DIFF
--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -876,8 +876,7 @@ mod tests {
         // Should take one byte off the end
         assert_eq!(u.arbitrary_byte_size().unwrap(), 6);
         assert_eq!(u.len(), 9);
-        let mut v = vec![];
-        v.resize(260, 0);
+        let mut v = vec![0; 260];
         v.push(1);
         v.push(4);
         let mut u = Unstructured::new(&v);


### PR DESCRIPTION
Uses `vec![x; N]` instead of `v.resize(N, x)`.
Caught by [`clippy::slow_vector_initialization`](https://rust-lang.github.io/rust-clippy/rust-1.75.0/index.html#/slow_vector_initialization).