### PR TITLE
Implement `Arbitrary` for `SocketAddr{,V4,V6}`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use std::borrow::{Cow, ToOwned};
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::ffi::{CString, OsString};
 use std::hash::BuildHasher;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::ops::Bound;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -1185,6 +1185,59 @@ impl<'a> Arbitrary<'a> for IpAddr {
         size_hint::and(
             bool::size_hint(depth),
             size_hint::or(Ipv4Addr::size_hint(depth), Ipv6Addr::size_hint(depth)),
+        )
+    }
+}
+
+impl<'a> Arbitrary<'a> for SocketAddrV4 {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        Ok(SocketAddrV4::new(u.arbitrary()?, u.arbitrary()?))
+    }
+
+    #[inline]
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::and(Ipv4Addr::size_hint(depth), u16::size_hint(depth))
+    }
+}
+
+impl<'a> Arbitrary<'a> for SocketAddrV6 {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        Ok(SocketAddrV6::new(
+            u.arbitrary()?,
+            u.arbitrary()?,
+            u.arbitrary()?,
+            u.arbitrary()?,
+        ))
+    }
+
+    #[inline]
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::and(
+            Ipv6Addr::size_hint(depth),
+            size_hint::and(
+                u16::size_hint(depth),
+                size_hint::and(u32::size_hint(depth), u32::size_hint(depth)),
+            ),
+        )
+    }
+}
+
+impl<'a> Arbitrary<'a> for SocketAddr {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        if u.arbitrary()? {
+            Ok(SocketAddr::V4(u.arbitrary()?))
+        } else {
+            Ok(SocketAddr::V6(u.arbitrary()?))
+        }
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::and(
+            bool::size_hint(depth),
+            size_hint::or(
+                SocketAddrV4::size_hint(depth),
+                SocketAddrV6::size_hint(depth),
+            ),
         )
     }
 }


### PR DESCRIPTION
Closes #145 (barring more `std` types).