### PR TITLE
Deny derive attributes on enum variants

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -216,6 +216,7 @@ fn gen_arbitrary_method(
                 .iter()
                 .enumerate()
                 .map(|(i, variant)| {
+                    check_variant_attrs(variant)?;
                     let idx = i as u64;
                     let variant_name = &variant.ident;
                     construct(&variant.fields, |_, field| gen_constructor_for_field(field))
@@ -400,4 +401,19 @@ fn gen_constructor_for_field(field: &Field) -> Result<TokenStream> {
         FieldConstructor::Value(value) => quote!(#value),
     };
     Ok(ctor)
+}
+
+fn check_variant_attrs(variant: &Variant) -> Result<()> {
+    for attr in &variant.attrs {
+        if attr.path().is_ident(ARBITRARY_ATTRIBUTE_NAME) {
+            return Err(Error::new_spanned(
+                attr,
+                format!(
+                    "invalid `{}` attribute. it is unsupported on enum variants. try applying it to a field of the variant instead",
+                    ARBITRARY_ATTRIBUTE_NAME
+                ),
+            ));
+        }
+    }
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1666,5 +1666,14 @@ mod test {
 ///     x: T,
 /// }
 /// ```
+///
+/// Attempt to use the derive attribute on an enum variant:
+/// ```compile_fail
+/// #[derive(::arbitrary::Arbitrary)]
+/// enum Enum<T: Default> {
+///     #[arbitrary(default)]
+///     Variant(T),
+/// }
+/// ```
 #[cfg(all(doctest, feature = "derive"))]
 pub struct CompileFailTests;


### PR DESCRIPTION
Adds a check to produce an error when an enum variant with an `#[arbitrary]` derive attribute is encountered.
I did not implement the ability to apply the attribute transparently to single-field variants.

Preview:
```
error: invalid `arbitrary` attribute. it is unsupported on enum variants. try applying it to a field of the variant instead
 --> src\lib.rs:1675:5
  |
7 |     #[arbitrary(default)]
  |     ^^^^^^^^^^^^^^^^^^^^^
```

Closes #149 and #150.