### PR TITLE
Make usize's wire format independent of machine word size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,13 +359,36 @@ impl_arbitrary_for_integers! {
     u32;
     u64;
     u128;
-    usize;
     i8;
     i16;
     i32;
     i64;
     i128;
-    isize;
+}
+
+// Note: We forward Arbitrary for i/usize to i/u64 in order to simplify corpus
+// compatibility between 32-bit and 64-bit builds. This introduces dead space in
+// 32-bit builds but keeps the input layout independent of the build platform.
+impl<'a> Arbitrary<'a> for usize {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        u.arbitrary::<u64>().map(|x| x as usize)
+    }
+
+    #[inline]
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <u64 as Arbitrary>::size_hint(depth)
+    }
+}
+
+impl<'a> Arbitrary<'a> for isize {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        u.arbitrary::<i64>().map(|x| x as isize)
+    }
+
+    #[inline]
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <i64 as Arbitrary>::size_hint(depth)
+    }
 }
 
 macro_rules! impl_arbitrary_for_floats {


### PR DESCRIPTION
Hi,

I'm currently building Rust fuzzing targets for 32-bit as well as 64-bit platforms. (WASM, Native)
I'd like to be able to share the corpus/inputs between these builds but `arbitrary`'s wire format is not very portable at the moment. Full compatibility between inputs is not something we can or should strive to achieve, but this PR should cover all of the incompatibilities I've encountered. (Both direct use of `usize` in struct fields as well as indirect usage via `Vec<>` or similar containers)
Let me know if this is something you'd like to accept or reject.

Thanks!