### PR TITLE
Document bias and entropy-exhausted behavior

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,10 @@ pub enum Error {
     EmptyChoose,
     /// There was not enough underlying data to fulfill some request for raw
     /// bytes.
+    ///
+    /// Note that outside of [`Unstructured::bytes`][crate::Unstructured::bytes],
+    /// most APIs do *not* return this error when running out of underlying arbitrary bytes
+    /// but silently return some default value instead.
     NotEnoughData,
     /// The input bytes were not of the right format
     IncorrectFormat,

--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -273,6 +273,11 @@ impl<'a> Unstructured<'a> {
     /// Do not use this to generate the size of a collection. Use
     /// `arbitrary_len` instead.
     ///
+    /// The probability distribution of the return value is not necessarily uniform.
+    ///
+    /// Returns `range.start()`, not an error,
+    /// if this `Unstructured` [is empty][Unstructured::is_empty].
+    ///
     /// # Panics
     ///
     /// Panics if `range.start > range.end`. That is, the given range must be
@@ -376,8 +381,12 @@ impl<'a> Unstructured<'a> {
     ///
     /// This should only be used inside of `Arbitrary` implementations.
     ///
-    /// Returns an error if there is not enough underlying data to make a
-    /// choice or if no choices are provided.
+    /// The probability distribution of choices is not necessarily uniform.
+    ///
+    /// Returns the first choice, not an error,
+    /// if this `Unstructured` [is empty][Unstructured::is_empty].
+    ///
+    /// Returns an error if no choices are provided.
     ///
     /// # Examples
     ///
@@ -415,8 +424,12 @@ impl<'a> Unstructured<'a> {
     ///
     /// This should only be used inside of `Arbitrary` implementations.
     ///
-    /// Returns an error if there is not enough underlying data to make a
-    /// choice or if no choices are provided.
+    /// The probability distribution of choices is not necessarily uniform.
+    ///
+    /// Returns the first choice, not an error,
+    /// if this `Unstructured` [is empty][Unstructured::is_empty].
+    ///
+    /// Returns an error if no choices are provided.
     ///
     /// # Examples
     ///
@@ -447,6 +460,10 @@ impl<'a> Unstructured<'a> {
     }
 
     /// Choose a value in `0..len`.
+    ///
+    /// The probability distribution of return values is not necessarily uniform.
+    ///
+    /// Returns zero, not an error, if this `Unstructured` [is empty][Unstructured::is_empty].
     ///
     /// Returns an error if the `len` is zero.
     ///
@@ -491,7 +508,9 @@ impl<'a> Unstructured<'a> {
         Ok(idx)
     }
 
-    /// Generate a boolean according to the given ratio.
+    /// Generate a boolean which is true with probability approximately the given ratio.
+    ///
+    /// Returns true, not an error, if this `Unstructured` [is empty][Unstructured::is_empty].
     ///
     /// # Panics
     ///
@@ -511,7 +530,7 @@ impl<'a> Unstructured<'a> {
     /// let mut u = Unstructured::new(&my_data);
     ///
     /// if u.ratio(5, 7)? {
-    ///     // Take this branch 5/7 of the time.
+    ///     // Take this branch approximately 5/7 of the time.
     /// }
     /// # Ok(())
     /// # }


### PR DESCRIPTION
`choose` and `choose_iter` incorrectly claimed to return `Error::NotEnoughData` when they in fact default to the first choice. This also documents that default in various other APIs.

Additionally, `int_in_range` (and APIs that rely on it) has bias for non-power-of-two ranges. `u.int_in_range(0..=170)` for example will consume one byte of entropy, and take its value modulo 171 (the size of the range) to generate the returned integer. As a result, values in `0..=84` (the first ~half of the range) are twice as likely to get chosen as the rest (assuming the underlying bytes are uniform). In general, the result distribution is only uniform if the range size is a power of two (where the modulo just masks some bits).

It would be accurate to document that return values are biased towards lower values when the range size is not a power of two, but do we want this much detail in the documented “contract” of this method?

Similarly, I just called `ratio` “approximate”. `u.ratio(5, 7)` returns true for 184 out of 256 possible underlying byte values, ~0.6% too often. In the worst case, `u.ratio(84, 170)` return true ~33% too often.

Notably, `#[derive(Arbitrary)]` chooses enum variants not with `choose_index` (although that seems most appropriate from reading `Unstructured` docs) but by always consuming 4 bytes of entropy:

```rust
// Use a multiply + shift to generate a ranged random number
// with slight bias. For details, see:
// https://lemire.me/blog/2016/06/30/fast-random-shuffling
Ok(match (u64::from(<u32 as arbitrary::Arbitrary>::arbitrary(u)?) * #count) >> 32 {
    #(#variants,)*
    _ => unreachable!()
})
```

`int_in_range` tries to minimize consumption based on the range size but that contributes to having more bias than multiply + shift. Is this a real trade-off worth having two methods?