### PR TITLE
Add faillible version of size_hint to properly handle recursive structures

### DIFF
--- a/src/foreign/alloc/borrow.rs
+++ b/src/foreign/alloc/borrow.rs
@@ -14,8 +14,13 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::recursion_guard(depth, |depth| {
-            <<A as ToOwned>::Owned as Arbitrary>::size_hint(depth)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
+        size_hint::try_recursion_guard(depth, |depth| {
+            <<A as ToOwned>::Owned as Arbitrary>::try_size_hint(depth)
         })
     }
 }

--- a/src/foreign/alloc/boxed.rs
+++ b/src/foreign/alloc/boxed.rs
@@ -13,7 +13,12 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::recursion_guard(depth, <A as Arbitrary>::size_hint)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
+        size_hint::try_recursion_guard(depth, <A as Arbitrary>::try_size_hint)
     }
 }
 

--- a/src/foreign/alloc/rc.rs
+++ b/src/foreign/alloc/rc.rs
@@ -13,7 +13,12 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::recursion_guard(depth, <A as Arbitrary>::size_hint)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
+        size_hint::try_recursion_guard(depth, <A as Arbitrary>::try_size_hint)
     }
 }
 

--- a/src/foreign/alloc/sync.rs
+++ b/src/foreign/alloc/sync.rs
@@ -13,7 +13,12 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::recursion_guard(depth, <A as Arbitrary>::size_hint)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
+        size_hint::try_recursion_guard(depth, <A as Arbitrary>::try_size_hint)
     }
 }
 

--- a/src/foreign/core/array.rs
+++ b/src/foreign/core/array.rs
@@ -64,9 +64,13 @@ where
     }
 
     #[inline]
-    fn size_hint(d: usize) -> (usize, Option<usize>) {
-        size_hint::and_all(&array::from_fn::<_, N, _>(|_| {
-            <T as Arbitrary>::size_hint(d)
-        }))
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
+        let hint = <T as Arbitrary>::try_size_hint(depth)?;
+        Ok(size_hint::and_all(&array::from_fn::<_, N, _>(|_| hint)))
     }
 }

--- a/src/foreign/core/cell.rs
+++ b/src/foreign/core/cell.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Arbitrary, Result, Unstructured},
+    crate::{Arbitrary, MaxRecursionReached, Result, Unstructured},
     core::cell::{Cell, RefCell, UnsafeCell},
 };
 
@@ -13,7 +13,12 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        <A as Arbitrary<'a>>::try_size_hint(depth)
     }
 }
 
@@ -27,7 +32,12 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        <A as Arbitrary<'a>>::try_size_hint(depth)
     }
 }
 
@@ -41,6 +51,11 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        <A as Arbitrary<'a>>::try_size_hint(depth)
     }
 }

--- a/src/foreign/core/num.rs
+++ b/src/foreign/core/num.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Arbitrary, Error, Result, Unstructured},
+    crate::{Arbitrary, Error, MaxRecursionReached, Result, Unstructured},
     core::{
         mem,
         num::{
@@ -131,6 +131,11 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        <A as Arbitrary<'a>>::try_size_hint(depth)
     }
 }

--- a/src/foreign/core/option.rs
+++ b/src/foreign/core/option.rs
@@ -1,4 +1,4 @@
-use crate::{size_hint, Arbitrary, Result, Unstructured};
+use crate::{size_hint, Arbitrary, MaxRecursionReached, Result, Unstructured};
 
 impl<'a, A> Arbitrary<'a> for Option<A>
 where
@@ -14,9 +14,14 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::and(
-            <bool as Arbitrary>::size_hint(depth),
-            size_hint::or((0, Some(0)), <A as Arbitrary>::size_hint(depth)),
-        )
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        Ok(size_hint::and(
+            <bool as Arbitrary>::try_size_hint(depth)?,
+            size_hint::or((0, Some(0)), <A as Arbitrary>::try_size_hint(depth)?),
+        ))
     }
 }

--- a/src/foreign/core/result.rs
+++ b/src/foreign/core/result.rs
@@ -1,4 +1,4 @@
-use crate::{size_hint, Arbitrary, Error, Unstructured};
+use crate::{size_hint, Arbitrary, Error, MaxRecursionReached, Unstructured};
 
 impl<'a, T, E> Arbitrary<'a> for Result<T, E>
 where
@@ -15,12 +15,17 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::and(
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        Ok(size_hint::and(
             <bool as Arbitrary>::size_hint(depth),
             size_hint::or(
-                <T as Arbitrary>::size_hint(depth),
-                <E as Arbitrary>::size_hint(depth),
+                <T as Arbitrary>::try_size_hint(depth)?,
+                <E as Arbitrary>::try_size_hint(depth)?,
             ),
-        )
+        ))
     }
 }

--- a/src/foreign/core/tuple.rs
+++ b/src/foreign/core/tuple.rs
@@ -1,4 +1,4 @@
-use crate::{size_hint, Arbitrary, Result, Unstructured};
+use crate::{size_hint, Arbitrary, MaxRecursionReached, Result, Unstructured};
 
 macro_rules! arbitrary_tuple {
     () => {};
@@ -23,10 +23,14 @@ macro_rules! arbitrary_tuple {
 
             #[inline]
             fn size_hint(depth: usize) -> (usize, Option<usize>) {
-                size_hint::and_all(&[
-                    <$last as Arbitrary>::size_hint(depth),
-                    $( <$xs as Arbitrary>::size_hint(depth) ),*
-                ])
+                Self::try_size_hint(depth).unwrap_or_default()
+            }
+            #[inline]
+            fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+                Ok(size_hint::and_all(&[
+                    <$last as Arbitrary>::try_size_hint(depth)?,
+                    $( <$xs as Arbitrary>::try_size_hint(depth)?),*
+                ]))
             }
         }
     };

--- a/src/foreign/std/sync.rs
+++ b/src/foreign/std/sync.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Arbitrary, Result, Unstructured},
+    crate::{Arbitrary, MaxRecursionReached, Result, Unstructured},
     std::sync::Mutex,
 };
 
@@ -13,6 +13,11 @@ where
 
     #[inline]
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        A::try_size_hint(depth)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,9 @@ pub use derive_arbitrary::*;
 pub use unstructured::Unstructured;
 
 /// Error indicating that the maximum recursion depth has been reached while calculating [`Arbitrary::size_hint`]()
-#[derive(Debug, Clone, Copy)]
-pub struct MaxRecursionReached;
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct MaxRecursionReached {}
 
 impl core::fmt::Display for MaxRecursionReached {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -40,7 +40,7 @@ pub fn try_recursion_guard(
     f: impl FnOnce(usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached>,
 ) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
     if depth > MAX_DEPTH {
-        Err(crate::MaxRecursionReached)
+        Err(crate::MaxRecursionReached {})
     } else {
         f(depth + 1)
     }

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -1,6 +1,8 @@
 //! Utilities for working with and combining the results of
 //! [`Arbitrary::size_hint`][crate::Arbitrary::size_hint].
 
+pub(crate) const MAX_DEPTH: usize = 20;
+
 /// Protects against potential infinite recursion when calculating size hints
 /// due to indirect type recursion.
 ///
@@ -8,14 +10,37 @@
 /// size hint.
 ///
 /// Otherwise, returns the default size hint: `(0, None)`.
+///
+/// <div class="warning">This method is deprecated. Users should instead implement <a href="../trait.Arbitrary.html#method.try_size_hint"><code>try_size_hint</code></a> and use <a href="fn.try_recursion_guard.html"><code>try_recursion_guard</code></a></div>
 #[inline]
+#[deprecated(note = "use `try_recursion_guard` instead")]
 pub fn recursion_guard(
     depth: usize,
     f: impl FnOnce(usize) -> (usize, Option<usize>),
 ) -> (usize, Option<usize>) {
-    const MAX_DEPTH: usize = 20;
     if depth > MAX_DEPTH {
         (0, None)
+    } else {
+        f(depth + 1)
+    }
+}
+
+/// Protects against potential infinite recursion when calculating size hints
+/// due to indirect type recursion.
+///
+/// When the depth is not too deep, calls `f` with `depth + 1` to calculate the
+/// size hint.
+///
+/// Otherwise, returns an error.
+///
+/// This should be used when implementing [`try_size_hint`](crate::Arbitrary::try_size_hint)
+#[inline]
+pub fn try_recursion_guard(
+    depth: usize,
+    f: impl FnOnce(usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached>,
+) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
+    if depth > MAX_DEPTH {
+        Err(crate::MaxRecursionReached)
     } else {
         f(depth + 1)
     }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -149,13 +149,86 @@ enum RecursiveTree {
     },
 }
 
+#[derive(Arbitrary, Debug)]
+struct WideRecursiveStruct {
+    a: Option<Box<WideRecursiveStruct>>,
+    b: Option<Box<WideRecursiveStruct>>,
+    c: Option<Box<WideRecursiveStruct>>,
+    d: Option<Box<WideRecursiveStruct>>,
+    e: Option<Box<WideRecursiveStruct>>,
+    f: Option<Box<WideRecursiveStruct>>,
+    g: Option<Box<WideRecursiveStruct>>,
+    h: Option<Box<WideRecursiveStruct>>,
+    i: Option<Box<WideRecursiveStruct>>,
+    k: Option<Box<WideRecursiveStruct>>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum WideRecursiveEnum {
+    None,
+    A(Box<WideRecursiveStruct>),
+    B(Box<WideRecursiveStruct>),
+    C(Box<WideRecursiveStruct>),
+    D(Box<WideRecursiveStruct>),
+    E(Box<WideRecursiveStruct>),
+    F(Box<WideRecursiveStruct>),
+    G(Box<WideRecursiveStruct>),
+    H(Box<WideRecursiveStruct>),
+    I(Box<WideRecursiveStruct>),
+    K(Box<WideRecursiveStruct>),
+}
+
+#[derive(Arbitrary, Debug)]
+enum WideRecursiveMixedEnum {
+    None,
+    A(Box<WideRecursiveMixedEnum>),
+    B(Box<WideRecursiveMixedEnum>),
+    C(Box<WideRecursiveMixedEnum>),
+    D(Box<WideRecursiveMixedEnum>),
+    E(Box<WideRecursiveMixedEnum>),
+    F(Box<WideRecursiveMixedStruct>),
+    G(Box<WideRecursiveMixedStruct>),
+    H(Box<WideRecursiveMixedStruct>),
+    I(Box<WideRecursiveMixedStruct>),
+    K(Box<WideRecursiveMixedStruct>),
+}
+
+#[derive(Arbitrary, Debug)]
+struct WideRecursiveMixedStruct {
+    a: Option<Box<WideRecursiveMixedEnum>>,
+    b: Option<Box<WideRecursiveMixedEnum>>,
+    c: Option<Box<WideRecursiveMixedEnum>>,
+    d: Option<Box<WideRecursiveMixedEnum>>,
+    e: Option<Box<WideRecursiveMixedEnum>>,
+    f: Option<Box<WideRecursiveMixedStruct>>,
+    g: Option<Box<WideRecursiveMixedStruct>>,
+    h: Option<Box<WideRecursiveMixedStruct>>,
+    i: Option<Box<WideRecursiveMixedStruct>>,
+    k: Option<Box<WideRecursiveMixedStruct>>,
+}
+
 #[test]
 fn recursive() {
     let raw = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
     let _rec: RecursiveTree = arbitrary_from(&raw);
+    let _rec: WideRecursiveStruct = arbitrary_from(&raw);
+    let _rec: WideRecursiveEnum = arbitrary_from(&raw);
+    let _rec: WideRecursiveMixedStruct = arbitrary_from(&raw);
+    let _rec: WideRecursiveMixedEnum = arbitrary_from(&raw);
+
+    assert_eq!((0, None), <WideRecursiveStruct as Arbitrary>::size_hint(0));
+    assert_eq!((0, None), <WideRecursiveEnum as Arbitrary>::size_hint(0));
+    assert_eq!(
+        (0, None),
+        <WideRecursiveMixedStruct as Arbitrary>::size_hint(0)
+    );
+    assert_eq!(
+        (0, None),
+        <WideRecursiveMixedEnum as Arbitrary>::size_hint(0)
+    );
 
     let (lower, upper) = <RecursiveTree as Arbitrary>::size_hint(0);
-    assert_eq!(lower, 4, "need a u32 for the discriminant at minimum");
+    assert_eq!(lower, 0, "Cannot compute size hint of recursive structure");
     assert!(
         upper.is_none(),
         "potentially infinitely recursive, so no upper bound"


### PR DESCRIPTION
The default implementation forwards to the current size_hint, so that it can be relied upon also for structures that still use the default implementation.

The default implementation of `size_hint` is not changed, so that it does not break existing implementations

Fix #144 