### PR TITLE
feat(derive): add variant-attribute `#[arbitrary(skip)]`

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.63.0"
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2", features = ['derive', 'parsing'] }
+syn = { version = "2", features = ['derive', 'parsing', 'extra-traits'] }
 
 [lib]
 proc_macro = true

--- a/derive/src/variant_attributes.rs
+++ b/derive/src/variant_attributes.rs
@@ -1,0 +1,21 @@
+use crate::ARBITRARY_ATTRIBUTE_NAME;
+use syn::*;
+
+pub fn not_skipped(variant: &&Variant) -> bool {
+    !should_skip(variant)
+}
+
+fn should_skip(Variant { attrs, .. }: &Variant) -> bool {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            attr.path()
+                .is_ident(ARBITRARY_ATTRIBUTE_NAME)
+                .then(|| attr.parse_args::<Meta>())
+                .and_then(Result::ok)
+        })
+        .any(|meta| match meta {
+            Meta::Path(path) => path.is_ident("skip"),
+            _ => false,
+        })
+}

--- a/examples/derive_enum.rs
+++ b/examples/derive_enum.rs
@@ -12,7 +12,13 @@ use arbitrary::{Arbitrary, Unstructured};
 enum MyEnum {
     UnitVariant,
     TupleVariant(bool, u32),
-    StructVariant { x: i8, y: (u8, i32) },
+    StructVariant {
+        x: i8,
+        y: (u8, i32),
+    },
+
+    #[arbitrary(skip)]
+    SkippedVariant(usize),
 }
 
 fn main() {

--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -237,20 +237,20 @@ impl<'a> Unstructured<'a> {
 
             // We only consume as many bytes as necessary to cover the entire
             // range of the byte string.
-            // Note: We cast to u64 so we don't overflow when checking std::u32::MAX + 4 on 32-bit archs
-            let len = if self.data.len() as u64 <= std::u8::MAX as u64 + 1 {
+            // Note: We cast to u64 so we don't overflow when checking u32::MAX + 4 on 32-bit archs
+            let len = if self.data.len() as u64 <= u8::MAX as u64 + 1 {
                 let bytes = 1;
                 let max_size = self.data.len() - bytes;
                 let (rest, for_size) = self.data.split_at(max_size);
                 self.data = rest;
                 Self::int_in_range_impl(0..=max_size as u8, for_size.iter().copied())?.0 as usize
-            } else if self.data.len() as u64 <= std::u16::MAX as u64 + 2 {
+            } else if self.data.len() as u64 <= u16::MAX as u64 + 2 {
                 let bytes = 2;
                 let max_size = self.data.len() - bytes;
                 let (rest, for_size) = self.data.split_at(max_size);
                 self.data = rest;
                 Self::int_in_range_impl(0..=max_size as u16, for_size.iter().copied())?.0 as usize
-            } else if self.data.len() as u64 <= std::u32::MAX as u64 + 4 {
+            } else if self.data.len() as u64 <= u32::MAX as u64 + 4 {
                 let bytes = 4;
                 let max_size = self.data.len() - bytes;
                 let (rest, for_size) = self.data.split_at(max_size);

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -116,6 +116,30 @@ fn derive_enum() {
     assert_eq!((4, Some(17)), <MyEnum as Arbitrary>::size_hint(0));
 }
 
+// This should result in a compiler-error:
+// #[derive(Arbitrary, Debug)]
+// enum Never {
+//     #[arbitrary(skip)]
+//     Nope,
+// }
+
+#[derive(Arbitrary, Debug)]
+enum SkipVariant {
+    Always,
+    #[arbitrary(skip)]
+    Never,
+}
+
+#[test]
+fn test_skip_variant() {
+    (0..=u8::MAX).for_each(|byte| {
+        let buffer = [byte];
+        let unstructured = Unstructured::new(&buffer);
+        let skip_variant = SkipVariant::arbitrary_take_rest(unstructured).unwrap();
+        assert!(!matches!(skip_variant, SkipVariant::Never));
+    })
+}
+
 #[derive(Arbitrary, Debug)]
 enum RecursiveTree {
     Leaf,


### PR DESCRIPTION
This commit introduces the first variant-attribute: `skip`. Its purpose is to skip variants, that should not be generated. E.g. they might be required for parsing objects, but should not be serialized (e.g. `#[serde(skip_serializing)]`).