### PR TITLE
[WIP] feat: introduce ArbitraryInRange

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     NotEnoughData,
     /// The input bytes were not of the right format
     IncorrectFormat,
+    /// Cannot generate value in given range
+    InvalidRange,
 }
 
 impl fmt::Display for Error {
@@ -28,6 +30,7 @@ impl fmt::Display for Error {
                 f,
                 "The raw data is not of the correct format to construct this type"
             ),
+            Error::InvalidRange => write!(f, "Cannot generate a value in given range"),
         }
     }
 }

--- a/src/foreign/alloc/boxed.rs
+++ b/src/foreign/alloc/boxed.rs
@@ -1,39 +1,10 @@
 use {
-    crate::{size_hint, Arbitrary, Result, Unstructured},
+    crate::{Arbitrary, Result, Unstructured},
     std::boxed::Box,
 };
 
-impl<'a, A> Arbitrary<'a> for Box<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::recursion_guard(depth, <A as Arbitrary>::size_hint)
-    }
-}
-
-impl<'a, A> Arbitrary<'a> for Box<[A]>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_wrapped_new! { Box! }
+implement_from_iter! { Box<[A]> }
 
 impl<'a> Arbitrary<'a> for Box<str> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {

--- a/src/foreign/alloc/collections/binary_heap.rs
+++ b/src/foreign/alloc/collections/binary_heap.rs
@@ -1,22 +1,3 @@
-use {
-    crate::{Arbitrary, Result, Unstructured},
-    std::collections::binary_heap::BinaryHeap,
-};
+use std::collections::binary_heap::BinaryHeap;
 
-impl<'a, A> Arbitrary<'a> for BinaryHeap<A>
-where
-    A: Arbitrary<'a> + Ord,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_from_iter! { BinaryHeap<A>: Ord }

--- a/src/foreign/alloc/collections/btree_set.rs
+++ b/src/foreign/alloc/collections/btree_set.rs
@@ -1,22 +1,3 @@
-use {
-    crate::{Arbitrary, Result, Unstructured},
-    std::collections::btree_set::BTreeSet,
-};
+use std::collections::btree_set::BTreeSet;
 
-impl<'a, A> Arbitrary<'a> for BTreeSet<A>
-where
-    A: Arbitrary<'a> + Ord,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_from_iter! { BTreeSet<A>: Ord }

--- a/src/foreign/alloc/collections/linked_list.rs
+++ b/src/foreign/alloc/collections/linked_list.rs
@@ -1,22 +1,3 @@
-use {
-    crate::{Arbitrary, Result, Unstructured},
-    std::collections::linked_list::LinkedList,
-};
+use std::collections::linked_list::LinkedList;
 
-impl<'a, A> Arbitrary<'a> for LinkedList<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_from_iter! { LinkedList<A> }

--- a/src/foreign/alloc/collections/vec_deque.rs
+++ b/src/foreign/alloc/collections/vec_deque.rs
@@ -1,22 +1,3 @@
-use {
-    crate::{Arbitrary, Result, Unstructured},
-    std::collections::vec_deque::VecDeque,
-};
+use std::collections::vec_deque::VecDeque;
 
-impl<'a, A> Arbitrary<'a> for VecDeque<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_from_iter! { VecDeque<A> }

--- a/src/foreign/alloc/rc.rs
+++ b/src/foreign/alloc/rc.rs
@@ -1,39 +1,10 @@
 use {
-    crate::{size_hint, Arbitrary, Result, Unstructured},
+    crate::{Arbitrary, Result, Unstructured},
     std::rc::Rc,
 };
 
-impl<'a, A> Arbitrary<'a> for Rc<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::recursion_guard(depth, <A as Arbitrary>::size_hint)
-    }
-}
-
-impl<'a, A> Arbitrary<'a> for Rc<[A]>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_wrapped_new! { Rc! }
+implement_from_iter! { Rc<[A]> }
 
 impl<'a> Arbitrary<'a> for Rc<str> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {

--- a/src/foreign/alloc/string.rs
+++ b/src/foreign/alloc/string.rs
@@ -1,7 +1,19 @@
 use {
-    crate::{Arbitrary, Result, Unstructured},
-    std::string::String,
+    crate::{Arbitrary, ArbitraryInRange, Result, Unstructured},
+    std::{ops::RangeBounds, string::String},
 };
+
+impl<'a> ArbitraryInRange<'a> for String {
+    type Bound = char;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+    where
+        R: RangeBounds<Self::Bound>,
+    {
+        u.arbitrary_in_range_iter::<Self::Bound, _>(range)?
+            .collect()
+    }
+}
 
 impl<'a> Arbitrary<'a> for String {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {

--- a/src/foreign/alloc/sync.rs
+++ b/src/foreign/alloc/sync.rs
@@ -1,39 +1,10 @@
 use {
-    crate::{size_hint, Arbitrary, Result, Unstructured},
+    crate::{Arbitrary, Result, Unstructured},
     std::sync::Arc,
 };
 
-impl<'a, A> Arbitrary<'a> for Arc<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        size_hint::recursion_guard(depth, <A as Arbitrary>::size_hint)
-    }
-}
-
-impl<'a, A> Arbitrary<'a> for Arc<[A]>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_wrapped_new! { Arc! }
+implement_from_iter! { Arc<[A]> }
 
 impl<'a> Arbitrary<'a> for Arc<str> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {

--- a/src/foreign/alloc/vec.rs
+++ b/src/foreign/alloc/vec.rs
@@ -1,22 +1,3 @@
-use {
-    crate::{Arbitrary, Result, Unstructured},
-    std::vec::Vec,
-};
+use std::vec::Vec;
 
-impl<'a, A> Arbitrary<'a> for Vec<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_iter()?.collect()
-    }
-
-    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
-        u.arbitrary_take_rest_iter()?.collect()
-    }
-
-    #[inline]
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, None)
-    }
-}
+implement_from_iter! { Vec<A> }

--- a/src/foreign/core/cell.rs
+++ b/src/foreign/core/cell.rs
@@ -1,46 +1,5 @@
-use {
-    crate::{Arbitrary, Result, Unstructured},
-    core::cell::{Cell, RefCell, UnsafeCell},
-};
+use core::cell::{Cell, RefCell, UnsafeCell};
 
-impl<'a, A> Arbitrary<'a> for Cell<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
-    }
-}
-
-impl<'a, A> Arbitrary<'a> for RefCell<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
-    }
-}
-
-impl<'a, A> Arbitrary<'a> for UnsafeCell<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
-    }
-}
+implement_wrapped_new! { Cell }
+implement_wrapped_new! { RefCell }
+implement_wrapped_new! { UnsafeCell }

--- a/src/foreign/core/char.rs
+++ b/src/foreign/core/char.rs
@@ -1,20 +1,74 @@
-use crate::{Arbitrary, Result, Unstructured};
+use {
+    crate::{Arbitrary, ArbitraryInRange, Error, Result, Unstructured},
+    core::ops::{Bound, RangeBounds},
+};
+
+/// The lower limit of the surrogates block:
+const SURROGATES_LOWER: u32 = 0xd800;
+
+/// The lower limit of the surrogates block:
+const SURROGATES_UPPER: u32 = 0xdfff;
+
+fn map_char_bound(character: Bound<&char>) -> Bound<u32> {
+    match character {
+        Bound::Included(character) => Bound::Included(u32::from(*character)),
+        Bound::Excluded(character) => Bound::Excluded(u32::from(*character)),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+impl<'a> ArbitraryInRange<'a> for char {
+    type Bound = Self;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+    where
+        R: RangeBounds<Self::Bound>,
+    {
+        let minimum = map_char_bound(range.start_bound());
+        let maximum = map_char_bound(range.end_bound());
+        let range = (minimum, maximum);
+
+        // In the range of valid unicode characters (['\0', char::MAX]),
+        //   there is a block called surrogates ([SURROGATES_LOWER, SURROGATES_UPPER]).
+        let character = match (
+            range.contains(&SURROGATES_LOWER),
+            range.contains(&SURROGATES_UPPER),
+        ) {
+            // If SURROGATES_LOWER is not in range but SURROGATES_UPPER is, fix the lower bound:
+            (false, true) => {
+                u32::arbitrary_in_range(u, &(Bound::Excluded(SURROGATES_UPPER), maximum))
+            }
+
+            // If SURROGATES_LOWER is in range but SURROGATES_UPPER not, fix the upper bound:
+            (true, false) => {
+                u32::arbitrary_in_range(u, &(minimum, Bound::Excluded(SURROGATES_LOWER)))
+            }
+
+            // If the entire surrogate-block is inside range, choose one of:
+            // * minimum .. SURROGATES_LOWER
+            // * SURROGATES_UPPER .. maximum
+            (true, true) => bool::arbitrary(u).and_then(|coin_flip| {
+                let range = match coin_flip {
+                    true => (Bound::Excluded(SURROGATES_UPPER), maximum),
+                    false => (minimum, Bound::Excluded(SURROGATES_LOWER)),
+                };
+                u32::arbitrary_in_range(u, &range)
+            }),
+
+            // If neither the lower nor upper bound of the surrogate block is within the range,
+            //   the range is either entirely below, above or within the surrogate block.
+            // In this case, either all values of the given range are valid characters or none.
+            _ => u32::arbitrary_in_range(u, &(minimum, maximum)),
+        };
+
+        // InvalidRange will be returned if range is entirely within the surrogate block.
+        char::from_u32(character?).ok_or(Error::InvalidRange)
+    }
+}
 
 impl<'a> Arbitrary<'a> for char {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        // The highest unicode code point is 0x11_FFFF
-        const CHAR_END: u32 = 0x11_0000;
-        // The size of the surrogate blocks
-        const SURROGATES_START: u32 = 0xD800;
-        let mut c = <u32 as Arbitrary<'a>>::arbitrary(u)? % CHAR_END;
-        if let Some(c) = char::from_u32(c) {
-            Ok(c)
-        } else {
-            // We found a surrogate, wrap and try again
-            c -= SURROGATES_START;
-            Ok(char::from_u32(c)
-                .expect("Generated character should be valid! This is a bug in arbitrary-rs"))
-        }
+        char::arbitrary_in_range(u, &..)
     }
 
     #[inline]

--- a/src/foreign/core/num.rs
+++ b/src/foreign/core/num.rs
@@ -1,28 +1,51 @@
 use {
-    crate::{Arbitrary, Error, Result, Unstructured},
+    crate::{Arbitrary, ArbitraryInRange, Error, Result, Unstructured},
     core::{
         mem,
         num::{
             NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
-            NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Wrapping,
+            NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Saturating, Wrapping,
         },
+        ops::{Bound, RangeBounds},
     },
 };
 
+#[inline]
+fn map_bound<T, U, F>(bound: Bound<T>, f: F) -> Bound<U>
+where
+    F: FnOnce(T) -> U,
+{
+    match bound {
+        Bound::Included(bound) => Bound::Included(f(bound)),
+        Bound::Excluded(bound) => Bound::Excluded(f(bound)),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
 macro_rules! impl_arbitrary_for_integers {
-    ( $( $ty:ty; )* ) => {
+    ( $( $ty:ty: $actual:ty; )* ) => {
         $(
+            impl<'a> ArbitraryInRange<'a> for $ty {
+                type Bound = Self;
+
+                fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+                where
+                    R: RangeBounds<Self::Bound>
+                {
+                    let minimum = map_bound(range.start_bound(), |x| *x as Self);
+                    let maximum = map_bound(range.start_bound(), |x| *x as Self);
+                    u.int_in_range((minimum, maximum))
+                }
+            }
+
             impl<'a> Arbitrary<'a> for $ty {
                 fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-                    let mut buf = [0; mem::size_of::<$ty>()];
-                    u.fill_buffer(&mut buf)?;
-                    Ok(Self::from_le_bytes(buf))
+                    Self::arbitrary_in_range(u, &..)
                 }
 
                 #[inline]
                 fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-                    let n = mem::size_of::<$ty>();
-                    (n, Some(n))
+                    (0, Some(mem::size_of::<$actual>()))
                 }
 
             }
@@ -30,42 +53,22 @@ macro_rules! impl_arbitrary_for_integers {
     }
 }
 
-impl_arbitrary_for_integers! {
-    u8;
-    u16;
-    u32;
-    u64;
-    u128;
-    i8;
-    i16;
-    i32;
-    i64;
-    i128;
-}
-
 // Note: We forward Arbitrary for i/usize to i/u64 in order to simplify corpus
 // compatibility between 32-bit and 64-bit builds. This introduces dead space in
 // 32-bit builds but keeps the input layout independent of the build platform.
-impl<'a> Arbitrary<'a> for usize {
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary::<u64>().map(|x| x as usize)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <u64 as Arbitrary>::size_hint(depth)
-    }
-}
-
-impl<'a> Arbitrary<'a> for isize {
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        u.arbitrary::<i64>().map(|x| x as isize)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <i64 as Arbitrary>::size_hint(depth)
-    }
+impl_arbitrary_for_integers! {
+    u8: u8;
+    u16: u16;
+    u32: u32;
+    u64: u64;
+    u128: u128;
+    usize: u64;
+    i8: i8;
+    i16: i16;
+    i32: i32;
+    i64: i64;
+    i128: i128;
+    isize: i64;
 }
 
 macro_rules! impl_arbitrary_for_floats {
@@ -92,12 +95,23 @@ impl_arbitrary_for_floats! {
 
 macro_rules! implement_nonzero_int {
     ($nonzero:ty, $int:ty) => {
+        impl<'a> ArbitraryInRange<'a> for $nonzero {
+            type Bound = $int;
+
+            fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+            where
+                R: RangeBounds<Self::Bound>,
+            {
+                Self::new(<$int as ArbitraryInRange<'a>>::arbitrary_in_range(
+                    u, range,
+                )?)
+                .ok_or(Error::InvalidRange)
+            }
+        }
+
         impl<'a> Arbitrary<'a> for $nonzero {
             fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-                match Self::new(<$int as Arbitrary<'a>>::arbitrary(u)?) {
-                    Some(n) => Ok(n),
-                    None => Err(Error::IncorrectFormat),
-                }
+                Self::new(<$int as Arbitrary<'a>>::arbitrary(u)?).ok_or(Error::IncorrectFormat)
             }
 
             #[inline]
@@ -121,16 +135,48 @@ implement_nonzero_int! { NonZeroU64, u64 }
 implement_nonzero_int! { NonZeroU128, u128 }
 implement_nonzero_int! { NonZeroUsize, usize }
 
-impl<'a, A> Arbitrary<'a> for Wrapping<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Wrapping)
-    }
+macro_rules! implement_wrapped {
+    ($outer:ident) => {
+        impl<'a, A> ArbitraryInRange<'a> for $outer<A>
+        where
+            A: ArbitraryInRange<'a>,
+        {
+            type Bound = A::Bound;
 
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
-    }
+            fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+            where
+                R: RangeBounds<Self::Bound>,
+            {
+                A::arbitrary_in_range(u, range).map($outer)
+            }
+
+            fn arbitrary_in_range_take_rest<R>(u: Unstructured<'a>, range: &R) -> Result<Self>
+            where
+                R: RangeBounds<Self::Bound>,
+            {
+                A::arbitrary_in_range_take_rest(u, range).map($outer)
+            }
+        }
+
+        impl<'a, A> Arbitrary<'a> for $outer<A>
+        where
+            A: Arbitrary<'a>,
+        {
+            fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+                A::arbitrary(u).map($outer)
+            }
+
+            fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
+                A::arbitrary_take_rest(u).map($outer)
+            }
+
+            #[inline]
+            fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                <A as Arbitrary<'a>>::size_hint(depth)
+            }
+        }
+    };
 }
+
+implement_wrapped! { Saturating }
+implement_wrapped! { Wrapping }

--- a/src/foreign/core/ops.rs
+++ b/src/foreign/core/ops.rs
@@ -100,7 +100,7 @@ where
     A: Arbitrary<'a>,
 {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        match u.int_in_range::<u8>(0..=2)? {
+        match u.int_in_range(0..=2u8)? {
             0 => Ok(Bound::Included(A::arbitrary(u)?)),
             1 => Ok(Bound::Excluded(A::arbitrary(u)?)),
             2 => Ok(Bound::Unbounded),

--- a/src/foreign/core/option.rs
+++ b/src/foreign/core/option.rs
@@ -1,4 +1,25 @@
-use crate::{size_hint, Arbitrary, Result, Unstructured};
+use {
+    crate::{size_hint, Arbitrary, ArbitraryInRange, Result, Unstructured},
+    core::ops::RangeBounds,
+};
+
+impl<'a, A> ArbitraryInRange<'a> for Option<A>
+where
+    A: ArbitraryInRange<'a>,
+{
+    type Bound = A::Bound;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+    where
+        R: RangeBounds<Self::Bound>,
+    {
+        Ok(if <bool as Arbitrary<'a>>::arbitrary(u)? {
+            Some(A::arbitrary_in_range(u, range)?)
+        } else {
+            None
+        })
+    }
+}
 
 impl<'a, A> Arbitrary<'a> for Option<A>
 where
@@ -6,7 +27,7 @@ where
 {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         Ok(if <bool as Arbitrary<'a>>::arbitrary(u)? {
-            Some(Arbitrary::arbitrary(u)?)
+            Some(A::arbitrary(u)?)
         } else {
             None
         })

--- a/src/foreign/core/sync/atomic.rs
+++ b/src/foreign/core/sync/atomic.rs
@@ -1,6 +1,9 @@
 use {
-    crate::{Arbitrary, Result, Unstructured},
-    core::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize},
+    crate::{Arbitrary, ArbitraryInRange, Result, Unstructured},
+    core::sync::atomic::{
+        AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
+        AtomicU64, AtomicU8, AtomicUsize,
+    },
 };
 
 impl<'a> Arbitrary<'a> for AtomicBool {
@@ -14,24 +17,13 @@ impl<'a> Arbitrary<'a> for AtomicBool {
     }
 }
 
-impl<'a> Arbitrary<'a> for AtomicIsize {
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <isize as Arbitrary<'a>>::size_hint(depth)
-    }
-}
-
-impl<'a> Arbitrary<'a> for AtomicUsize {
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <usize as Arbitrary<'a>>::size_hint(depth)
-    }
-}
+implement_new! { AtomicI8: i8 }
+implement_new! { AtomicI16: i16 }
+implement_new! { AtomicI32: i32 }
+implement_new! { AtomicI64: i64 }
+implement_new! { AtomicIsize: isize }
+implement_new! { AtomicU8: u8 }
+implement_new! { AtomicU16: u16 }
+implement_new! { AtomicU32: u32 }
+implement_new! { AtomicU64: u64 }
+implement_new! { AtomicUsize: usize }

--- a/src/foreign/core/time.rs
+++ b/src/foreign/core/time.rs
@@ -1,13 +1,74 @@
 use {
-    crate::{size_hint, Arbitrary, Result, Unstructured},
-    core::time::Duration,
+    crate::{size_hint, Arbitrary, ArbitraryInRange, Result, Unstructured},
+    core::{
+        ops::{Bound, RangeBounds},
+        time::Duration,
+    },
 };
 
+const MAX_NANOS: u32 = 999_999_999;
+
+fn split_duration(duration: &Duration) -> (u64, u32) {
+    (
+        duration.as_secs(),
+        // We can assume, that this is always in the range 0–MAX_NANOS
+        duration.subsec_nanos(),
+    )
+}
+
+fn split_bound_duration(duration: Bound<&Duration>) -> (Bound<u64>, Bound<u32>) {
+    match duration {
+        Bound::Included(duration) => {
+            let (secs, nanos) = split_duration(duration);
+            (Bound::Included(secs), Bound::Included(nanos))
+        }
+        Bound::Excluded(duration) => {
+            let (secs, nanos) = split_duration(duration);
+            (Bound::Excluded(secs), Bound::Excluded(nanos))
+        }
+        Bound::Unbounded => (Bound::Unbounded, Bound::Unbounded),
+    }
+}
+
+impl<'a> ArbitraryInRange<'a> for Duration {
+    type Bound = Self;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+    where
+        R: RangeBounds<Self::Bound>,
+    {
+        let (start_secs, start_nanos) = split_bound_duration(range.start_bound());
+        let (end_secs, end_nanos) = split_bound_duration(range.end_bound());
+        let secs = u64::arbitrary_in_range(u, &(start_secs, end_secs))?;
+
+        // If secs is not the minimum, nanos can start at 0.
+        let start_nanos = match start_secs {
+            Bound::Included(start_secs) => (secs == start_secs).then_some(start_nanos),
+            Bound::Excluded(start_secs) => (secs == start_secs + 1).then_some(start_nanos),
+            // If start_secs is unbounded, start_nanos is too
+            Bound::Unbounded => None,
+        };
+        let start_nanos = start_nanos.unwrap_or(Bound::Unbounded);
+
+        // If secs is not the maximum, nanos can end at 999_999_999.
+        let end_nanos = match end_secs {
+            Bound::Included(end_secs) => (end_secs == secs).then_some(end_nanos),
+            Bound::Excluded(end_secs) => (end_secs == secs + 1).then_some(end_nanos),
+            // If end_secs is unbounded, end_nanos is too
+            Bound::Unbounded => None,
+        };
+        let end_nanos = end_nanos.unwrap_or(Bound::Included(MAX_NANOS));
+
+        let nanos = u32::arbitrary_in_range(u, &(start_nanos, end_nanos))?;
+
+        Ok(Self::new(secs, nanos))
+    }
+}
 impl<'a> Arbitrary<'a> for Duration {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         Ok(Self::new(
             <u64 as Arbitrary>::arbitrary(u)?,
-            u.int_in_range(0..=999_999_999)?,
+            u.int_in_range(0..=MAX_NANOS)?,
         ))
     }
 

--- a/src/foreign/mod.rs
+++ b/src/foreign/mod.rs
@@ -2,6 +2,134 @@
 //!
 //! [`Arbitrary`]: crate::Arbitrary
 
+macro_rules! implement_from_iter {
+    ($outer:ident <$inner:ty> $(: $($bound:ident),+)?) => {
+        impl<'a, A> crate::ArbitraryInRange<'a> for $outer<$inner>
+        where
+            A: crate::ArbitraryInRange<'a> $($(+ $bound)+)?,
+        {
+            type Bound = A::Bound;
+
+            fn arbitrary_in_range<R>(
+                u: &mut crate::Unstructured<'a>,
+                range: &R,
+            ) -> crate::Result<Self>
+            where
+                R: core::ops::RangeBounds<Self::Bound>,
+            {
+                u.arbitrary_in_range_iter(range)?.collect()
+            }
+        }
+
+        impl<'a, A> crate::Arbitrary<'a> for $outer<$inner>
+        where
+            A: crate::Arbitrary<'a> $($(+ $bound)+)?,
+        {
+            fn arbitrary(u: &mut crate::Unstructured<'a>) -> crate::Result<Self> {
+                u.arbitrary_iter()?.collect()
+            }
+
+            fn arbitrary_take_rest(u: crate::Unstructured<'a>) -> crate::Result<Self> {
+                u.arbitrary_take_rest_iter()?.collect()
+            }
+
+            #[inline]
+            fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+                (0, None)
+            }
+        }
+    };
+}
+
+macro_rules! implement_new {
+    ($ty:ty: $bound:ty) => {
+        impl<'a> ArbitraryInRange<'a> for $ty {
+            type Bound = $bound;
+
+            fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+            where
+                R: core::ops::RangeBounds<Self::Bound>,
+            {
+                <$bound as ArbitraryInRange<'a>>::arbitrary_in_range(u, range).map(Self::new)
+            }
+        }
+
+        impl<'a> Arbitrary<'a> for $ty {
+            fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+                <$bound as Arbitrary<'a>>::arbitrary(u).map(Self::new)
+            }
+
+            #[inline]
+            fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                <$bound as Arbitrary<'a>>::size_hint(depth)
+            }
+        }
+    };
+}
+
+macro_rules! implement_wrapped_new {
+    ($outer:ident) => {
+        implement_wrapped_new! {
+            $outer @
+            fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                <A as crate::Arbitrary<'a>>::size_hint(depth)
+            }
+        }
+    };
+    ($outer:ident!) => {
+        implement_wrapped_new! {
+            $outer @
+            fn size_hint(depth: usize) -> (usize, Option<usize>) {
+                crate::size_hint::recursion_guard(depth, <A as Arbitrary>::size_hint)
+            }
+        }
+    };
+    ($outer:ident @ $size_hint:item) => {
+        impl<'a, A> crate::ArbitraryInRange<'a> for $outer<A>
+        where
+            A: crate::ArbitraryInRange<'a>,
+        {
+            type Bound = A::Bound;
+
+            fn arbitrary_in_range<R>(
+                u: &mut crate::Unstructured<'a>,
+                range: &R,
+            ) -> crate::Result<Self>
+            where
+                R: core::ops::RangeBounds<Self::Bound>,
+            {
+                A::arbitrary_in_range(u, range).map($outer::new)
+            }
+
+            fn arbitrary_in_range_take_rest<R>(
+                u: crate::Unstructured<'a>,
+                range: &R,
+            ) -> crate::Result<Self>
+            where
+                R: core::ops::RangeBounds<Self::Bound>,
+            {
+                A::arbitrary_in_range_take_rest(u, range).map($outer::new)
+            }
+        }
+
+        impl<'a, A> crate::Arbitrary<'a> for $outer<A>
+        where
+            A: crate::Arbitrary<'a>,
+        {
+            fn arbitrary(u: &mut crate::Unstructured<'a>) -> crate::Result<Self> {
+                A::arbitrary(u).map($outer::new)
+            }
+
+            fn arbitrary_take_rest(u: crate::Unstructured<'a>) -> crate::Result<Self> {
+                A::arbitrary_take_rest(u).map($outer::new)
+            }
+
+            #[inline]
+            $size_hint
+        }
+    };
+}
+
 mod alloc;
 mod core;
 mod std;

--- a/src/foreign/std/collections/hash_set.rs
+++ b/src/foreign/std/collections/hash_set.rs
@@ -1,10 +1,26 @@
 use {
-    crate::{Arbitrary, Result, Unstructured},
+    crate::{Arbitrary, ArbitraryInRange, Result, Unstructured},
     std::{
         collections::hash_set::HashSet,
         hash::{BuildHasher, Hash},
+        ops::RangeBounds,
     },
 };
+
+impl<'a, A, S> ArbitraryInRange<'a> for HashSet<A, S>
+where
+    A: ArbitraryInRange<'a> + Eq + Hash,
+    S: BuildHasher + Default,
+{
+    type Bound = A::Bound;
+
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+    where
+        R: RangeBounds<Self::Bound>,
+    {
+        u.arbitrary_in_range_iter(range)?.collect()
+    }
+}
 
 impl<'a, A, S> Arbitrary<'a> for HashSet<A, S>
 where

--- a/src/foreign/std/sync.rs
+++ b/src/foreign/std/sync.rs
@@ -1,18 +1,3 @@
-use {
-    crate::{Arbitrary, Result, Unstructured},
-    std::sync::Mutex,
-};
+use std::sync::Mutex;
 
-impl<'a, A> Arbitrary<'a> for Mutex<A>
-where
-    A: Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Arbitrary::arbitrary(u).map(Self::new)
-    }
-
-    #[inline]
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <A as Arbitrary<'a>>::size_hint(depth)
-    }
-}
+implement_wrapped_new! { Mutex }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,16 @@ pub mod unstructured;
 #[cfg(test)]
 mod tests;
 
-pub use error::*;
+pub use {
+    self::error::{Error, Result},
+    core::ops::RangeBounds,
+};
 
 #[cfg(feature = "derive_arbitrary")]
 pub use derive_arbitrary::*;
 
 #[doc(inline)]
-pub use unstructured::Unstructured;
+pub use self::unstructured::Unstructured;
 
 /// Generate arbitrary structured values from raw, unstructured data.
 ///
@@ -291,6 +294,40 @@ pub trait Arbitrary<'a>: Sized {
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
         let _ = depth;
         (0, None)
+    }
+}
+
+/// Generate arbitrary structured values in a given range from raw, unstructured data.
+///
+/// This trait is similar to [`Arbitrary`], but for ordered types,
+///   even though it is not required for `Self` to implement [`PartialOrd`] or even [`Ord`].
+pub trait ArbitraryInRange<'a>: Sized {
+    /// The type of the range bounds.
+    ///
+    /// Usually, this is equal to `Self`, but some wrapping types like [`Option<T>`],
+    ///   which only make sense as range bounds if `T` can be used as range bounds,
+    ///   it might be more useful to use the wrapped/inner type `T` instead.
+    type Bound;
+
+    /// Generate an arbitrary value of `Self` in given `range`.
+    ///
+    /// See also the documentation of [`Arbitrary::arbitrary`].
+    fn arbitrary_in_range<R>(u: &mut Unstructured<'a>, range: &R) -> Result<Self>
+    where
+        R: RangeBounds<Self::Bound>;
+
+    /// Generate an arbitrary value of `Self` in given `range`
+    ///   from the entirety of the given unstructured data.
+    ///
+    /// Unlike [`ArbitraryInRange::arbitrary`], which borrows the source of `unstructured` data,
+    ///   this method will take ownership and thus can only be called by the last consumer.
+    ///
+    /// See also the documentation for [`Unstructured`].
+    fn arbitrary_in_range_take_rest<R>(mut u: Unstructured<'a>, range: &R) -> Result<Self>
+    where
+        R: RangeBounds<Self::Bound>,
+    {
+        Self::arbitrary_in_range(&mut u, range)
     }
 }
 

--- a/src/unstructured/integer.rs
+++ b/src/unstructured/integer.rs
@@ -1,0 +1,144 @@
+//! FIXME: Missing Documentation.
+
+use core::{
+    fmt::Debug,
+    mem,
+    ops::{BitOr, Rem, Shl, Shr, Sub},
+};
+
+/// A trait that is implemented for all of the primitive integers:
+///
+/// * `u8`
+/// * `u16`
+/// * `u32`
+/// * `u64`
+/// * `u128`
+/// * `usize`
+/// * `i8`
+/// * `i16`
+/// * `i32`
+/// * `i64`
+/// * `i128`
+/// * `isize`
+///
+/// Don't implement this trait yourself.
+pub trait Int:
+    Copy
+    + Debug
+    + PartialOrd
+    + Ord
+    + Sub<Self, Output = Self>
+    + Rem<Self, Output = Self>
+    + Shr<Self, Output = Self>
+    + Shl<usize, Output = Self>
+    + BitOr<Self, Output = Self>
+{
+    #[doc(hidden)]
+    type Unsigned: Int;
+
+    #[doc(hidden)]
+    type Array: Default + AsMut<[u8]>;
+
+    #[doc(hidden)]
+    const ZERO: Self;
+
+    #[doc(hidden)]
+    const ONE: Self;
+
+    #[doc(hidden)]
+    const MIN: Self;
+
+    #[doc(hidden)]
+    const MAX: Self;
+
+    #[doc(hidden)]
+    fn from_u8(b: u8) -> Self;
+
+    #[doc(hidden)]
+    fn from_bytes(bytes: Self::Array) -> Self;
+
+    #[doc(hidden)]
+    fn from_usize(u: usize) -> Self;
+
+    #[doc(hidden)]
+    fn checked_add(self, rhs: Self) -> Option<Self>;
+
+    #[doc(hidden)]
+    fn wrapping_add(self, rhs: Self) -> Self;
+
+    #[doc(hidden)]
+    fn wrapping_sub(self, rhs: Self) -> Self;
+
+    #[doc(hidden)]
+    fn to_unsigned(self) -> Self::Unsigned;
+
+    #[doc(hidden)]
+    fn from_unsigned(unsigned: Self::Unsigned) -> Self;
+}
+
+macro_rules! impl_int {
+    ( $( $ty:ty : $unsigned_ty: ty ; )* ) => {
+        $(
+            impl Int for $ty {
+                type Unsigned = $unsigned_ty;
+
+                type Array = [u8; mem::size_of::<$ty>()];
+
+                const ZERO: Self = 0;
+
+                const ONE: Self = 1;
+
+                const MIN: Self = Self::MIN;
+
+                const MAX: Self = Self::MAX;
+
+                fn from_u8(b: u8) -> Self {
+                    b as Self
+                }
+
+                fn from_bytes(bytes: Self::Array) -> Self {
+                    Self::from_le_bytes(bytes)
+                }
+
+                fn from_usize(u: usize) -> Self {
+                    u as Self
+                }
+
+                fn checked_add(self, rhs: Self) -> Option<Self> {
+                    <$ty>::checked_add(self, rhs)
+                }
+
+                fn wrapping_add(self, rhs: Self) -> Self {
+                    <$ty>::wrapping_add(self, rhs)
+                }
+
+                fn wrapping_sub(self, rhs: Self) -> Self {
+                    <$ty>::wrapping_sub(self, rhs)
+                }
+
+                fn to_unsigned(self) -> Self::Unsigned {
+                    self as $unsigned_ty
+                }
+
+                fn from_unsigned(unsigned: $unsigned_ty) -> Self {
+                    unsigned as Self
+                }
+            }
+        )*
+    }
+}
+
+impl_int! {
+    u8: u8;
+    u16: u16;
+    u32: u32;
+    u64: u64;
+    u128: u128;
+    usize: usize;
+    i8: u8;
+    i16: u16;
+    i32: u32;
+    i64: u64;
+    i128: u128;
+    isize: usize;
+}

--- a/src/unstructured/iterators.rs
+++ b/src/unstructured/iterators.rs
@@ -1,0 +1,106 @@
+//! FIXME: Missing Documentation.
+
+use {
+    super::Unstructured,
+    crate::{Arbitrary, ArbitraryInRange, Result},
+    core::{marker::PhantomData, ops::RangeBounds},
+};
+
+/// Utility iterator produced by [`Unstructured::arbitrary_iter`]
+pub struct ArbitraryIter<'a, 'b, ElementType> {
+    u: &'b mut Unstructured<'a>,
+    _marker: PhantomData<ElementType>,
+}
+
+impl<'a, 'b, ElementType> ArbitraryIter<'a, 'b, ElementType> {
+    /// Construct a new arbitrary iterator consuming all the remaining bytes.
+    pub fn new(u: &'b mut Unstructured<'a>) -> Self {
+        Self {
+            u,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, 'b, ElementType: Arbitrary<'a>> Iterator for ArbitraryIter<'a, 'b, ElementType> {
+    type Item = Result<ElementType>;
+    fn next(&mut self) -> Option<Result<ElementType>> {
+        let keep_going = self.u.arbitrary().unwrap_or(false);
+        if keep_going {
+            Some(Arbitrary::arbitrary(self.u))
+        } else {
+            None
+        }
+    }
+}
+
+/// Utility iterator produced by [`Unstructured::arbitrary_in_range_iter`]
+pub struct ArbitraryInRangeIter<'a, 'u, 'r, ElementType, Range>
+where
+    ElementType: ArbitraryInRange<'a>,
+    Range: RangeBounds<ElementType::Bound>,
+{
+    u: &'u mut Unstructured<'a>,
+    range: &'r Range,
+    _marker: PhantomData<ElementType>,
+}
+
+impl<'a, 'u, 'r, ElementType, Range> ArbitraryInRangeIter<'a, 'u, 'r, ElementType, Range>
+where
+    ElementType: ArbitraryInRange<'a>,
+    Range: RangeBounds<ElementType::Bound>,
+{
+    /// Construct a new arbitrary iterator consuming all the remaining bytes.
+    pub fn new(u: &'u mut Unstructured<'a>, range: &'r Range) -> Self {
+        Self {
+            u,
+            range,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, 'u, 'r, ElementType, Range> Iterator
+    for ArbitraryInRangeIter<'a, 'u, 'r, ElementType, Range>
+where
+    ElementType: ArbitraryInRange<'a>,
+    Range: RangeBounds<ElementType::Bound>,
+{
+    type Item = Result<ElementType>;
+    fn next(&mut self) -> Option<Result<ElementType>> {
+        let keep_going = self.u.arbitrary().unwrap_or(false);
+        if keep_going {
+            Some(ArbitraryInRange::arbitrary_in_range(self.u, self.range))
+        } else {
+            None
+        }
+    }
+}
+
+/// Utility iterator produced by [`Unstructured::arbitrary_take_rest_iter`]
+pub struct ArbitraryTakeRestIter<'a, ElementType> {
+    u: Unstructured<'a>,
+    _marker: PhantomData<ElementType>,
+}
+
+impl<'a, ElementType> ArbitraryTakeRestIter<'a, ElementType> {
+    /// Construct a new arbitrary iterator consuming all the remaining bytes.
+    pub fn new(u: Unstructured<'a>) -> Self {
+        Self {
+            u,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, ElementType: Arbitrary<'a>> Iterator for ArbitraryTakeRestIter<'a, ElementType> {
+    type Item = Result<ElementType>;
+    fn next(&mut self) -> Option<Result<ElementType>> {
+        let keep_going = self.u.arbitrary().unwrap_or(false);
+        if keep_going {
+            Some(Arbitrary::arbitrary(&mut self.u))
+        } else {
+            None
+        }
+    }
+}

--- a/src/unstructured/mod.rs
+++ b/src/unstructured/mod.rs
@@ -8,10 +8,26 @@
 
 //! Wrappers around raw, unstructured bytes.
 
-use crate::{Arbitrary, Error, Result};
-use std::marker::PhantomData;
-use std::ops::ControlFlow;
-use std::{mem, ops};
+pub mod integer;
+pub mod iterators;
+
+#[cfg(test)]
+mod tests;
+
+use {
+    crate::{Arbitrary, ArbitraryInRange, Error, Result},
+    core::{
+        cmp,
+        fmt::Debug,
+        mem,
+        ops::{Bound, ControlFlow, RangeBounds},
+    },
+};
+
+pub use self::{
+    integer::Int,
+    iterators::{ArbitraryInRangeIter, ArbitraryIter, ArbitraryTakeRestIter},
+};
 
 /// A source of unstructured data.
 ///
@@ -186,9 +202,9 @@ impl<'a> Unstructured<'a> {
     ///
     /// ```
     /// use arbitrary::{Arbitrary, Result, Unstructured};
-    /// # pub struct MyCollection<T> { _t: std::marker::PhantomData<T> }
+    /// # pub struct MyCollection<T> { _t: core::marker::PhantomData<T> }
     /// # impl<T> MyCollection<T> {
-    /// #     pub fn with_capacity(capacity: usize) -> Self { MyCollection { _t: std::marker::PhantomData } }
+    /// #     pub fn with_capacity(capacity: usize) -> Self { MyCollection { _t: core::marker::PhantomData } }
     /// #     pub fn insert(&mut self, element: T) {}
     /// # }
     ///
@@ -218,7 +234,7 @@ impl<'a> Unstructured<'a> {
         let byte_size = self.arbitrary_byte_size()?;
         let (lower, upper) = <ElementType as Arbitrary>::size_hint(0);
         let elem_size = upper.unwrap_or(lower * 2);
-        let elem_size = std::cmp::max(1, elem_size);
+        let elem_size = cmp::max(1, elem_size);
         Ok(byte_size / elem_size)
     }
 
@@ -243,25 +259,25 @@ impl<'a> Unstructured<'a> {
                 let max_size = self.data.len() - bytes;
                 let (rest, for_size) = self.data.split_at(max_size);
                 self.data = rest;
-                Self::int_in_range_impl(0..=max_size as u8, for_size.iter().copied())?.0 as usize
+                Self::int_in_range_impl(..=max_size as u8, for_size)?.0 as usize
             } else if self.data.len() as u64 <= u16::MAX as u64 + 2 {
                 let bytes = 2;
                 let max_size = self.data.len() - bytes;
                 let (rest, for_size) = self.data.split_at(max_size);
                 self.data = rest;
-                Self::int_in_range_impl(0..=max_size as u16, for_size.iter().copied())?.0 as usize
+                Self::int_in_range_impl(..=max_size as u16, for_size)?.0 as usize
             } else if self.data.len() as u64 <= u32::MAX as u64 + 4 {
                 let bytes = 4;
                 let max_size = self.data.len() - bytes;
                 let (rest, for_size) = self.data.split_at(max_size);
                 self.data = rest;
-                Self::int_in_range_impl(0..=max_size as u32, for_size.iter().copied())?.0 as usize
+                Self::int_in_range_impl(..=max_size as u32, for_size)?.0 as usize
             } else {
                 let bytes = 8;
                 let max_size = self.data.len() - bytes;
                 let (rest, for_size) = self.data.split_at(max_size);
                 self.data = rest;
-                Self::int_in_range_impl(0..=max_size as u64, for_size.iter().copied())?.0 as usize
+                Self::int_in_range_impl(..=max_size as u64, for_size)?.0 as usize
             };
 
             Ok(len)
@@ -291,35 +307,20 @@ impl<'a> Unstructured<'a> {
     /// assert!(-5_000 <= x);
     /// assert!(x <= -1_000);
     /// ```
-    pub fn int_in_range<T>(&mut self, range: ops::RangeInclusive<T>) -> Result<T>
+    pub fn int_in_range<T, R>(&mut self, range: R) -> Result<T>
     where
         T: Int,
+        R: RangeBounds<T>,
     {
-        let (result, bytes_consumed) = Self::int_in_range_impl(range, self.data.iter().cloned())?;
+        let (result, bytes_consumed) = Self::int_in_range_impl(range, self.data)?;
         self.data = &self.data[bytes_consumed..];
         Ok(result)
     }
 
-    fn int_in_range_impl<T>(
-        range: ops::RangeInclusive<T>,
-        mut bytes: impl Iterator<Item = u8>,
-    ) -> Result<(T, usize)>
+    fn int_in_bounds<T>(start: T, end: T, mut bytes: impl Iterator<Item = u8>) -> (T, usize)
     where
         T: Int,
     {
-        let start = *range.start();
-        let end = *range.end();
-        assert!(
-            start <= end,
-            "`arbitrary::Unstructured::int_in_range` requires a non-empty range"
-        );
-
-        // When there is only one possible choice, don't waste any entropy from
-        // the underlying data.
-        if start == end {
-            return Ok((start, 0));
-        }
-
         // From here on out we work with the unsigned representation. All of the
         // operations performed below work out just as well whether or not `T`
         // is a signed or unsigned integer.
@@ -366,10 +367,49 @@ impl<'a> Unstructured<'a> {
 
         // And convert back to our maybe-signed representation.
         let result = T::from_unsigned(result);
-        debug_assert!(*range.start() <= result);
-        debug_assert!(result <= *range.end());
 
-        Ok((result, bytes_consumed))
+        (result, bytes_consumed)
+    }
+
+    fn int_in_range_impl<T, R>(range: R, bytes: &[u8]) -> Result<(T, usize)>
+    where
+        T: Int,
+        R: RangeBounds<T>,
+    {
+        let start = match range.start_bound() {
+            Bound::Included(x) => Ok(*x),
+            Bound::Excluded(x) if *x == T::MAX => Err(Error::InvalidRange),
+            Bound::Excluded(x) => Ok((*x).wrapping_add(T::ONE)),
+            Bound::Unbounded => Ok(T::MIN),
+        }?;
+        let end = match range.end_bound() {
+            Bound::Included(x) => Ok(*x),
+            Bound::Excluded(x) if *x == T::MIN => Err(Error::InvalidRange),
+            Bound::Excluded(x) => Ok((*x).wrapping_sub(T::ONE)),
+            Bound::Unbounded => Ok(T::MAX),
+        }?;
+
+        if start == end {
+            // If there is only one possible choice,
+            //   don't waste any entropy from the underlying data.
+            Ok((start, 0))
+        } else if start == T::MIN && end == T::MAX {
+            // If a value from the type’s full range is requested,
+            //   don't waste time computing, just return any value.
+            let mut buf: T::Array = <_>::default();
+
+            let bytes_consumed = cmp::min(mem::size_of::<T>(), bytes.len());
+            (buf.as_mut()[..bytes_consumed]).copy_from_slice(&bytes[..bytes_consumed]);
+
+            Ok((T::from_bytes(buf), bytes_consumed))
+        } else if start < end {
+            // The difficult part
+            let (result, bytes_consumed) = Self::int_in_bounds(start, end, bytes.iter().copied());
+            debug_assert!(range.contains(&result));
+            Ok((result, bytes_consumed))
+        } else {
+            Err(Error::InvalidRange)
+        }
     }
 
     /// Choose one of the given choices.
@@ -555,7 +595,7 @@ impl<'a> Unstructured<'a> {
     /// assert_eq!(buf, [0, 0]);
     /// ```
     pub fn fill_buffer(&mut self, buffer: &mut [u8]) -> Result<()> {
-        let n = std::cmp::min(buffer.len(), self.data.len());
+        let n = cmp::min(buffer.len(), self.data.len());
         buffer[..n].copy_from_slice(&self.data[..n]);
         for byte in buffer[n..].iter_mut() {
             *byte = 0;
@@ -642,10 +682,22 @@ impl<'a> Unstructured<'a> {
     pub fn arbitrary_iter<'b, ElementType: Arbitrary<'a>>(
         &'b mut self,
     ) -> Result<ArbitraryIter<'a, 'b, ElementType>> {
-        Ok(ArbitraryIter {
-            u: &mut *self,
-            _marker: PhantomData,
-        })
+        Ok(ArbitraryIter::new(&mut *self))
+    }
+
+    /// Provide an iterator over elements for constructing a collection with elements in range
+    ///
+    /// This is useful for implementing [`Arbitrary::arbitrary`] on collections
+    /// since the implementation is simply `u.arbitrary_iter()?.collect()`
+    pub fn arbitrary_in_range_iter<'u, 'r, ElementType, Range>(
+        &'u mut self,
+        range: &'r Range,
+    ) -> Result<ArbitraryInRangeIter<'a, 'u, 'r, ElementType, Range>>
+    where
+        ElementType: ArbitraryInRange<'a>,
+        Range: RangeBounds<ElementType::Bound>,
+    {
+        Ok(ArbitraryInRangeIter::new(&mut *self, range))
     }
 
     /// Provide an iterator over elements for constructing a collection from
@@ -656,23 +708,19 @@ impl<'a> Unstructured<'a> {
     pub fn arbitrary_take_rest_iter<ElementType: Arbitrary<'a>>(
         self,
     ) -> Result<ArbitraryTakeRestIter<'a, ElementType>> {
-        Ok(ArbitraryTakeRestIter {
-            u: self,
-            _marker: PhantomData,
-        })
+        Ok(ArbitraryTakeRestIter::new(self))
     }
 
     /// Call the given function an arbitrary number of times.
     ///
-    /// The function is given this `Unstructured` so that it can continue to
-    /// generate arbitrary data and structures.
+    /// The function is given this `Unstructured`
+    ///   so that it can continue to generate arbitrary data and structures.
     ///
-    /// You may optionaly specify minimum and maximum bounds on the number of
-    /// times the function is called.
+    /// You may optionaly specify minimum and maximum bounds
+    ///   on the number of times the function is called.
     ///
-    /// You may break out of the loop early by returning
-    /// `Ok(std::ops::ControlFlow::Break)`. To continue the loop, return
-    /// `Ok(std::ops::ControlFlow::Continue)`.
+    /// You may break out of the loop early by returning `Ok(ControlFlow::Break)`.
+    /// To continue the loop, return `Ok(ControlFlow::Continue)`.
     ///
     /// # Panics
     ///
@@ -680,12 +728,12 @@ impl<'a> Unstructured<'a> {
     ///
     /// # Example
     ///
-    /// Call a closure that generates an arbitrary type inside a context an
-    /// arbitrary number of times:
+    /// Call a closure that generates an arbitrary type
+    ///   inside a context an arbitrary number of times:
     ///
     /// ```
     /// use arbitrary::{Result, Unstructured};
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// enum Type {
     ///     /// A boolean type.
@@ -742,310 +790,5 @@ impl<'a> Unstructured<'a> {
         }
 
         Ok(())
-    }
-}
-
-/// Utility iterator produced by [`Unstructured::arbitrary_iter`]
-pub struct ArbitraryIter<'a, 'b, ElementType> {
-    u: &'b mut Unstructured<'a>,
-    _marker: PhantomData<ElementType>,
-}
-
-impl<'a, 'b, ElementType: Arbitrary<'a>> Iterator for ArbitraryIter<'a, 'b, ElementType> {
-    type Item = Result<ElementType>;
-    fn next(&mut self) -> Option<Result<ElementType>> {
-        let keep_going = self.u.arbitrary().unwrap_or(false);
-        if keep_going {
-            Some(Arbitrary::arbitrary(self.u))
-        } else {
-            None
-        }
-    }
-}
-
-/// Utility iterator produced by [`Unstructured::arbitrary_take_rest_iter`]
-pub struct ArbitraryTakeRestIter<'a, ElementType> {
-    u: Unstructured<'a>,
-    _marker: PhantomData<ElementType>,
-}
-
-impl<'a, ElementType: Arbitrary<'a>> Iterator for ArbitraryTakeRestIter<'a, ElementType> {
-    type Item = Result<ElementType>;
-    fn next(&mut self) -> Option<Result<ElementType>> {
-        let keep_going = self.u.arbitrary().unwrap_or(false);
-        if keep_going {
-            Some(Arbitrary::arbitrary(&mut self.u))
-        } else {
-            None
-        }
-    }
-}
-
-/// A trait that is implemented for all of the primitive integers:
-///
-/// * `u8`
-/// * `u16`
-/// * `u32`
-/// * `u64`
-/// * `u128`
-/// * `usize`
-/// * `i8`
-/// * `i16`
-/// * `i32`
-/// * `i64`
-/// * `i128`
-/// * `isize`
-///
-/// Don't implement this trait yourself.
-pub trait Int:
-    Copy
-    + std::fmt::Debug
-    + PartialOrd
-    + Ord
-    + ops::Sub<Self, Output = Self>
-    + ops::Rem<Self, Output = Self>
-    + ops::Shr<Self, Output = Self>
-    + ops::Shl<usize, Output = Self>
-    + ops::BitOr<Self, Output = Self>
-{
-    #[doc(hidden)]
-    type Unsigned: Int;
-
-    #[doc(hidden)]
-    const ZERO: Self;
-
-    #[doc(hidden)]
-    const ONE: Self;
-
-    #[doc(hidden)]
-    const MAX: Self;
-
-    #[doc(hidden)]
-    fn from_u8(b: u8) -> Self;
-
-    #[doc(hidden)]
-    fn from_usize(u: usize) -> Self;
-
-    #[doc(hidden)]
-    fn checked_add(self, rhs: Self) -> Option<Self>;
-
-    #[doc(hidden)]
-    fn wrapping_add(self, rhs: Self) -> Self;
-
-    #[doc(hidden)]
-    fn wrapping_sub(self, rhs: Self) -> Self;
-
-    #[doc(hidden)]
-    fn to_unsigned(self) -> Self::Unsigned;
-
-    #[doc(hidden)]
-    fn from_unsigned(unsigned: Self::Unsigned) -> Self;
-}
-
-macro_rules! impl_int {
-    ( $( $ty:ty : $unsigned_ty: ty ; )* ) => {
-        $(
-            impl Int for $ty {
-                type Unsigned = $unsigned_ty;
-
-                const ZERO: Self = 0;
-
-                const ONE: Self = 1;
-
-                const MAX: Self = Self::MAX;
-
-                fn from_u8(b: u8) -> Self {
-                    b as Self
-                }
-
-                fn from_usize(u: usize) -> Self {
-                    u as Self
-                }
-
-                fn checked_add(self, rhs: Self) -> Option<Self> {
-                    <$ty>::checked_add(self, rhs)
-                }
-
-                fn wrapping_add(self, rhs: Self) -> Self {
-                    <$ty>::wrapping_add(self, rhs)
-                }
-
-                fn wrapping_sub(self, rhs: Self) -> Self {
-                    <$ty>::wrapping_sub(self, rhs)
-                }
-
-                fn to_unsigned(self) -> Self::Unsigned {
-                    self as $unsigned_ty
-                }
-
-                fn from_unsigned(unsigned: $unsigned_ty) -> Self {
-                    unsigned as Self
-                }
-            }
-        )*
-    }
-}
-
-impl_int! {
-    u8: u8;
-    u16: u16;
-    u32: u32;
-    u64: u64;
-    u128: u128;
-    usize: usize;
-    i8: u8;
-    i16: u16;
-    i32: u32;
-    i64: u64;
-    i128: u128;
-    isize: usize;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_byte_size() {
-        let mut u = Unstructured::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 6]);
-        // Should take one byte off the end
-        assert_eq!(u.arbitrary_byte_size().unwrap(), 6);
-        assert_eq!(u.len(), 9);
-        let mut v = vec![0; 260];
-        v.push(1);
-        v.push(4);
-        let mut u = Unstructured::new(&v);
-        // Should read two bytes off the end
-        assert_eq!(u.arbitrary_byte_size().unwrap(), 0x104);
-        assert_eq!(u.len(), 260);
-    }
-
-    #[test]
-    fn int_in_range_of_one() {
-        let mut u = Unstructured::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 6]);
-        let x = u.int_in_range(0..=0).unwrap();
-        assert_eq!(x, 0);
-        let choice = *u.choose(&[42]).unwrap();
-        assert_eq!(choice, 42)
-    }
-
-    #[test]
-    fn int_in_range_uses_minimal_amount_of_bytes() {
-        let mut u = Unstructured::new(&[1, 2]);
-        assert_eq!(1, u.int_in_range::<u8>(0..=u8::MAX).unwrap());
-        assert_eq!(u.len(), 1);
-
-        let mut u = Unstructured::new(&[1, 2]);
-        assert_eq!(1, u.int_in_range::<u32>(0..=u8::MAX as u32).unwrap());
-        assert_eq!(u.len(), 1);
-
-        let mut u = Unstructured::new(&[1]);
-        assert_eq!(1, u.int_in_range::<u32>(0..=u8::MAX as u32 + 1).unwrap());
-        assert!(u.is_empty());
-    }
-
-    #[test]
-    fn int_in_range_in_bounds() {
-        for input in u8::MIN..=u8::MAX {
-            let input = [input];
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(1..=u8::MAX).unwrap();
-            assert_ne!(x, 0);
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(0..=u8::MAX - 1).unwrap();
-            assert_ne!(x, u8::MAX);
-        }
-    }
-
-    #[test]
-    fn int_in_range_covers_unsigned_range() {
-        // Test that we generate all values within the range given to
-        // `int_in_range`.
-
-        let mut full = [false; u8::MAX as usize + 1];
-        let mut no_zero = [false; u8::MAX as usize];
-        let mut no_max = [false; u8::MAX as usize];
-        let mut narrow = [false; 10];
-
-        for input in u8::MIN..=u8::MAX {
-            let input = [input];
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(0..=u8::MAX).unwrap();
-            full[x as usize] = true;
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(1..=u8::MAX).unwrap();
-            no_zero[x as usize - 1] = true;
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(0..=u8::MAX - 1).unwrap();
-            no_max[x as usize] = true;
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(100..=109).unwrap();
-            narrow[x as usize - 100] = true;
-        }
-
-        for (i, covered) in full.iter().enumerate() {
-            assert!(covered, "full[{}] should have been generated", i);
-        }
-        for (i, covered) in no_zero.iter().enumerate() {
-            assert!(covered, "no_zero[{}] should have been generated", i);
-        }
-        for (i, covered) in no_max.iter().enumerate() {
-            assert!(covered, "no_max[{}] should have been generated", i);
-        }
-        for (i, covered) in narrow.iter().enumerate() {
-            assert!(covered, "narrow[{}] should have been generated", i);
-        }
-    }
-
-    #[test]
-    fn int_in_range_covers_signed_range() {
-        // Test that we generate all values within the range given to
-        // `int_in_range`.
-
-        let mut full = [false; u8::MAX as usize + 1];
-        let mut no_min = [false; u8::MAX as usize];
-        let mut no_max = [false; u8::MAX as usize];
-        let mut narrow = [false; 21];
-
-        let abs_i8_min: isize = 128;
-
-        for input in 0..=u8::MAX {
-            let input = [input];
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(i8::MIN..=i8::MAX).unwrap();
-            full[(x as isize + abs_i8_min) as usize] = true;
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(i8::MIN + 1..=i8::MAX).unwrap();
-            no_min[(x as isize + abs_i8_min - 1) as usize] = true;
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(i8::MIN..=i8::MAX - 1).unwrap();
-            no_max[(x as isize + abs_i8_min) as usize] = true;
-
-            let mut u = Unstructured::new(&input);
-            let x = u.int_in_range(-10..=10).unwrap();
-            narrow[(x as isize + 10) as usize] = true;
-        }
-
-        for (i, covered) in full.iter().enumerate() {
-            assert!(covered, "full[{}] should have been generated", i);
-        }
-        for (i, covered) in no_min.iter().enumerate() {
-            assert!(covered, "no_min[{}] should have been generated", i);
-        }
-        for (i, covered) in no_max.iter().enumerate() {
-            assert!(covered, "no_max[{}] should have been generated", i);
-        }
-        for (i, covered) in narrow.iter().enumerate() {
-            assert!(covered, "narrow[{}] should have been generated", i);
-        }
     }
 }

--- a/src/unstructured/tests.rs
+++ b/src/unstructured/tests.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+#[test]
+fn test_byte_size() {
+    let mut u = Unstructured::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 6]);
+    // Should take one byte off the end
+    assert_eq!(u.arbitrary_byte_size().unwrap(), 6);
+    assert_eq!(u.len(), 9);
+    let mut v = vec![0; 260];
+    v.push(1);
+    v.push(4);
+    let mut u = Unstructured::new(&v);
+    // Should read two bytes off the end
+    assert_eq!(u.arbitrary_byte_size().unwrap(), 0x104);
+    assert_eq!(u.len(), 260);
+}
+
+#[test]
+fn int_in_range_of_one() {
+    let mut u = Unstructured::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 6]);
+    let x = u.int_in_range(0..=0).unwrap();
+    assert_eq!(x, 0);
+    let choice = *u.choose(&[42]).unwrap();
+    assert_eq!(choice, 42)
+}
+
+#[test]
+fn int_in_range_uses_minimal_amount_of_bytes() {
+    let mut u = Unstructured::new(&[1, 2]);
+    assert_eq!(1, u.int_in_range::<u8, _>(..).unwrap());
+    assert_eq!(u.len(), 1);
+
+    let mut u = Unstructured::new(&[1, 2]);
+    assert_eq!(1, u.int_in_range::<u32, _>(..).unwrap());
+    assert_eq!(u.len(), 1);
+
+    let mut u = Unstructured::new(&[1]);
+    assert_eq!(1, u.int_in_range::<u32, _>(0..=u8::MAX as u32 + 1).unwrap());
+    assert!(u.is_empty());
+}
+
+#[test]
+fn int_in_range_in_bounds() {
+    for input in u8::MIN..=u8::MAX {
+        let input = [input];
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(1..=u8::MAX).unwrap();
+        assert_ne!(x, 0);
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(0..=u8::MAX - 1).unwrap();
+        assert_ne!(x, u8::MAX);
+    }
+}
+
+#[test]
+fn int_in_range_covers_unsigned_range() {
+    // Test that we generate all values within the range given to
+    // `int_in_range`.
+
+    let mut full = [false; u8::MAX as usize + 1];
+    let mut no_zero = [false; u8::MAX as usize];
+    let mut no_max = [false; u8::MAX as usize];
+    let mut narrow = [false; 10];
+
+    for input in u8::MIN..=u8::MAX {
+        let input = [input];
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(0..=u8::MAX).unwrap();
+        full[x as usize] = true;
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(1..=u8::MAX).unwrap();
+        no_zero[x as usize - 1] = true;
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(0..=u8::MAX - 1).unwrap();
+        no_max[x as usize] = true;
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(100..=109).unwrap();
+        narrow[x as usize - 100] = true;
+    }
+
+    for (i, covered) in full.iter().enumerate() {
+        assert!(covered, "full[{}] should have been generated", i);
+    }
+    for (i, covered) in no_zero.iter().enumerate() {
+        assert!(covered, "no_zero[{}] should have been generated", i);
+    }
+    for (i, covered) in no_max.iter().enumerate() {
+        assert!(covered, "no_max[{}] should have been generated", i);
+    }
+    for (i, covered) in narrow.iter().enumerate() {
+        assert!(covered, "narrow[{}] should have been generated", i);
+    }
+}
+
+#[test]
+fn int_in_range_covers_signed_range() {
+    // Test that we generate all values within the range given to
+    // `int_in_range`.
+
+    let mut full = [false; u8::MAX as usize + 1];
+    let mut no_min = [false; u8::MAX as usize];
+    let mut no_max = [false; u8::MAX as usize];
+    let mut narrow = [false; 21];
+
+    let abs_i8_min: isize = 128;
+
+    for input in 0..=u8::MAX {
+        let input = [input];
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(i8::MIN..=i8::MAX).unwrap();
+        full[(x as isize + abs_i8_min) as usize] = true;
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(i8::MIN + 1..=i8::MAX).unwrap();
+        no_min[(x as isize + abs_i8_min - 1) as usize] = true;
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(i8::MIN..=i8::MAX - 1).unwrap();
+        no_max[(x as isize + abs_i8_min) as usize] = true;
+
+        let mut u = Unstructured::new(&input);
+        let x = u.int_in_range(-10..=10).unwrap();
+        narrow[(x as isize + 10) as usize] = true;
+    }
+
+    for (i, covered) in full.iter().enumerate() {
+        assert!(covered, "full[{}] should have been generated", i);
+    }
+    for (i, covered) in no_min.iter().enumerate() {
+        assert!(covered, "no_min[{}] should have been generated", i);
+    }
+    for (i, covered) in no_max.iter().enumerate() {
+        assert!(covered, "no_max[{}] should have been generated", i);
+    }
+    for (i, covered) in narrow.iter().enumerate() {
+        assert!(covered, "narrow[{}] should have been generated", i);
+    }
+}


### PR DESCRIPTION
This PR introduces the trait `ArbitraryInRange`, which allows limiting the range of possible values for some types. The intention is to use this trait in an not-yet-implemented `[arbitrary(range(min = …, max = …))]` field-attribute. A separate trait is necessary, because 1. not all types can be meaningful used as ranges, 2. I like to use `#[arbitrary(range(min = 23, max = 42))]` on `Option<u8>`. 

However, there are certainly some implementations missing, so still WIP.