### PR TITLE
Add Arbitrary in range to trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub mod size_hint;
 use core::array;
 use core::cell::{Cell, RefCell, UnsafeCell};
 use core::iter;
-use core::mem;
+use std::{mem, ops};
 use core::num::{NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize};
 use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 use core::ops::{Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
@@ -208,6 +208,15 @@ pub trait Arbitrary<'a>: Sized {
     ///
     /// See also the documentation for [`Unstructured`][crate::Unstructured].
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self>;
+
+    /// Generate an arbitrary value of `Self` for a given range from unstructured data.
+    fn arbitrary_in_range<T>(u: &mut Unstructured<'a>, range: ops::RangeInclusive<T>) -> Result<Self>
+    where
+        T: crate::unstructured::Int,
+    {
+        let _r = range;
+        Self::arbitrary(u)
+    }
 
     /// Generate an arbitrary value of `Self` from the entirety of the given
     /// unstructured data.

--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -833,6 +833,9 @@ pub trait Int:
     fn wrapping_add(self, rhs: Self) -> Self;
 
     #[doc(hidden)]
+    fn to_u64(self) -> u64;
+
+    #[doc(hidden)]
     fn wrapping_sub(self, rhs: Self) -> Self;
 
     #[doc(hidden)]
@@ -876,6 +879,10 @@ macro_rules! impl_int {
 
                 fn to_unsigned(self) -> Self::Unsigned {
                     self as $unsigned_ty
+                }
+
+                fn to_u64(self) -> u64 {
+                    self as u64
                 }
 
                 fn from_unsigned(unsigned: $unsigned_ty) -> Self {


### PR DESCRIPTION
Looking for the ability to create an Arbitrary type from a range.

For example, Given a Type:

```rust
pub struct A(u64);
```

Then a type can be created from range with:
```rust
impl<'a> Arbitrary<'a> for A {
    fn arbitrary_in_range<T>(u: &mut Unstructured<'a>, range: ops::RangeInclusive<T>) -> Result<Self>
    where
        T: arbitrary::unstructured::Int,
    {
        let a = u.int_in_range(range)?.to_u64();
        Ok(A(a))
    }
}
```

Marking this as draft to request feedback about adding.  Cheers.