### PR TITLE
Use fully qualified path for Result when generated by macro

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -397,7 +397,7 @@ fn gen_size_hint_method(input: &DeriveInput) -> Result<TokenStream> {
                 }
 
                 #[inline]
-                fn try_size_hint(depth: usize) -> Result<(usize, ::core::option::Option<usize>), arbitrary::MaxRecursionReached> {
+                fn try_size_hint(depth: usize) -> ::core::result::Result<(usize, ::core::option::Option<usize>), arbitrary::MaxRecursionReached> {
                     arbitrary::size_hint::try_recursion_guard(depth, |depth| #hint)
                 }
             }
@@ -422,7 +422,7 @@ fn gen_size_hint_method(input: &DeriveInput) -> Result<TokenStream> {
                         Self::try_size_hint(depth).unwrap_or_default()
                     }
                     #[inline]
-                    fn try_size_hint(depth: usize) -> Result<(usize, ::core::option::Option<usize>), arbitrary::MaxRecursionReached> {
+                    fn try_size_hint(depth: usize) -> ::core::result::Result<(usize, ::core::option::Option<usize>), arbitrary::MaxRecursionReached> {
                         Ok(arbitrary::size_hint::and(
                             <u32 as arbitrary::Arbitrary>::try_size_hint(depth)?,
                             arbitrary::size_hint::try_recursion_guard(depth, |depth| {


### PR DESCRIPTION
Fixes #203