### PR TITLE
Test deriving arbitrary for a locally-defined `Result` type

### DIFF
--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -392,4 +392,11 @@ fn derive_structs_named_same_as_core() {
     }
 
     let _ = Default::arbitrary(&mut Unstructured::new(&[]));
+
+    #[derive(Debug, Arbitrary)]
+    struct Result {
+        f: core::result::Result<u32, u32>,
+    }
+
+    let _ = Result::arbitrary(&mut Unstructured::new(&[]));
 }


### PR DESCRIPTION
This adds a regression test that was missing in https://github.com/rust-fuzz/arbitrary/pull/205