### PR TITLE
Implement Arbitrary for core::cmp::Reverse

### DIFF
--- a/src/foreign/core/cmp.rs
+++ b/src/foreign/core/cmp.rs
@@ -1,0 +1,23 @@
+use {
+    crate::{size_hint, Arbitrary, Result, Unstructured},
+    core::cmp::Reverse,
+};
+
+impl<'a, A> Arbitrary<'a> for Reverse<A>
+where
+    A: Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        Arbitrary::arbitrary(u).map(Self)
+    }
+
+    #[inline]
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    #[inline]
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), crate::MaxRecursionReached> {
+        size_hint::try_recursion_guard(depth, <A as Arbitrary>::try_size_hint)
+    }
+}

--- a/src/foreign/core/mod.rs
+++ b/src/foreign/core/mod.rs
@@ -6,6 +6,7 @@ mod array;
 mod bool;
 mod cell;
 mod char;
+mod cmp;
 mod iter;
 mod marker;
 mod num;


### PR DESCRIPTION
We have a lot of data structures that depend on ordering requirements that we enforce via things like `BinaryHeap<Reverse<K>, V>`, so having `Reverse<T>: Arbitrary where T: Arbitrary` would be very useful for cutting down on a bunch of implementation boilerplate.

Edit: currently this fails clippy, but it seems like the failing code is unrelated to my diff, and is probably because of Rust 1.83 changing lint checks for elidable lifetimes.