### PR TITLE
Require exact version of `arbitrary-derive`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ documentation = "https://docs.rs/arbitrary/"
 rust-version = "1.63.0" # Keep in sync with version documented in the README.md
 
 [dependencies]
-derive_arbitrary = { version = "1.4.0", path = "./derive", optional = true }
+derive_arbitrary = { version = "~1.4.0", path = "./derive", optional = true }
 
 [features]
 # Turn this feature on to enable support for `#[derive(Arbitrary)]`.


### PR DESCRIPTION
`Arbitrary` had a new `try_size_hint` method added in #185 - while this was semver safe for `arbitrary` because a default implementation was provided which forwarded along, the new version of `arbitrary-derive` which follows the same versioning as `arbitrary` started generating `try_size_hint` methods, which causes v1.2.3 to fail to compile, as it tries to grab `arbitrary-derive` "1.2.3" from crates.io, which gets responded to with a "1.4.0" version. This means that `arbitrary-derive` technically has a semver break from 1.2.3 to 1.4.

Given that:
1. It is reasonable to evolve your traits this way, and it doesn't break semver on the base package
2. The patchlevel is specified on `arbitrary-derive`, so it seems the intent is to require a matching version
3. You likely want to keep the same version for your proc-macro as your main crate

This proposes using exact equality in the `Cargo.toml` so that future trait updates of this nature won't break the ability to build older packages via Cargo.