### PR TITLE
Don't generate invalid non-zero integers

### DIFF
--- a/src/foreign/core/num.rs
+++ b/src/foreign/core/num.rs
@@ -94,7 +94,7 @@ macro_rules! implement_nonzero_int {
     ($nonzero:ty, $int:ty) => {
         impl<'a> Arbitrary<'a> for $nonzero {
             fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-                match Self::new(<$int as Arbitrary<'a>>::arbitrary(u)?) {
+                match Self::new(<$int as Arbitrary<'a>>::arbitrary(u)?.saturating_add(1)) {
                     Some(n) => Ok(n),
                     None => Err(Error::IncorrectFormat),
                 }


### PR DESCRIPTION
For example, the instance for `NonZeroUsize` was generating code equivalent to this:

```rust
NonZeroUsize::new(u.arbitrary::<usize>()?)?
```

But `u.arbitrary::<usize>()` can generate 0, which will fail.