### PR TITLE
Add `no_std` Support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,15 @@ jobs:
     - run: rustup toolchain add 1.63
     - name: Build
       run: cargo +1.63 check --lib --all-features
+  check_no_std:
+    name: Check no_std
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: rustup toolchain add 1.82
+    - run: rustup target add x86_64-unknown-none
+    - run: cargo +1.82 check --no-default-features --features alloc,derive,core_error,core_net,alloc_ffi_cstring --target x86_64-unknown-none
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,19 @@ rust-version = "1.63.0" # Keep in sync with version documented in the README.md
 derive_arbitrary = { version = "~1.4.0", path = "./derive", optional = true }
 
 [features]
+default = ["std"]
 # Turn this feature on to enable support for `#[derive(Arbitrary)]`.
 derive = ["derive_arbitrary"]
+# Enables support for the `std` crate.
+std = ["alloc"]
+# Enables support for the `alloc` crate.
+alloc = []
+# Enables using core::error::Error. Increases MSRV to at least 1.81.0
+core_error = []
+# Enables using core::net when `std` is disabled. Increases MSRV to at least 1.77.0
+core_net = []
+# Enables using `alloc::ffi::CString` when `std` is disabled. Increases MSRV to at least 1.64.0
+alloc_ffi_cstring = ["alloc"]
 
 [[example]]
 name = "derive_enum"
@@ -40,3 +51,8 @@ members = ["./fuzz"]
 
 [dev-dependencies]
 exhaustigen = "0.1.0"
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -58,6 +58,8 @@ fn expand_derive_arbitrary(input: syn::DeriveInput) -> Result<TokenStream> {
 
     Ok(quote! {
         const _: () = {
+            extern crate std;
+
             ::std::thread_local! {
                 #[allow(non_upper_case_globals)]
                 static #recursive_count: ::core::cell::Cell<u32> = ::core::cell::Cell::new(0);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use core::fmt;
 
 /// An enumeration of buffer creation errors
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,20 +32,28 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+#[cfg(all(not(feature = "std"), feature = "core_error"))]
+impl core::error::Error for Error {}
 
 /// A `Result` with the error type fixed as `arbitrary::Error`.
 ///
 /// Either an `Ok(T)` or `Err(arbitrary::Error)`.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::string::String;
+
     // Often people will import our custom `Result` type because 99.9% of
     // results in a file will be `arbitrary::Result` but then have that one last
     // 0.1% that want to have a custom error type. Don't make them prefix that
-    // 0.1% as `std::result::Result`; instead, let `arbitrary::Result` have an
+    // 0.1% as `core::result::Result`; instead, let `arbitrary::Result` have an
     // overridable error type.
+    #[cfg(feature = "alloc")]
     #[test]
     fn can_use_custom_error_types_with_result() -> super::Result<(), String> {
         Ok(())

--- a/src/foreign/alloc/borrow.rs
+++ b/src/foreign/alloc/borrow.rs
@@ -1,6 +1,6 @@
 use {
     crate::{size_hint, Arbitrary, Result, Unstructured},
-    std::borrow::{Cow, ToOwned},
+    alloc::borrow::{Cow, ToOwned},
 };
 
 impl<'a, A> Arbitrary<'a> for Cow<'a, A>

--- a/src/foreign/alloc/boxed.rs
+++ b/src/foreign/alloc/boxed.rs
@@ -1,6 +1,6 @@
 use {
     crate::{size_hint, Arbitrary, Result, Unstructured},
-    std::boxed::Box,
+    alloc::{boxed::Box, string::String},
 };
 
 impl<'a, A> Arbitrary<'a> for Box<A>

--- a/src/foreign/alloc/collections/binary_heap.rs
+++ b/src/foreign/alloc/collections/binary_heap.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::collections::binary_heap::BinaryHeap,
+    alloc::collections::binary_heap::BinaryHeap,
 };
 
 impl<'a, A> Arbitrary<'a> for BinaryHeap<A>

--- a/src/foreign/alloc/collections/btree_map.rs
+++ b/src/foreign/alloc/collections/btree_map.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::collections::btree_map::BTreeMap,
+    alloc::collections::btree_map::BTreeMap,
 };
 
 impl<'a, K, V> Arbitrary<'a> for BTreeMap<K, V>

--- a/src/foreign/alloc/collections/btree_set.rs
+++ b/src/foreign/alloc/collections/btree_set.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::collections::btree_set::BTreeSet,
+    alloc::collections::btree_set::BTreeSet,
 };
 
 impl<'a, A> Arbitrary<'a> for BTreeSet<A>

--- a/src/foreign/alloc/collections/linked_list.rs
+++ b/src/foreign/alloc/collections/linked_list.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::collections::linked_list::LinkedList,
+    alloc::collections::linked_list::LinkedList,
 };
 
 impl<'a, A> Arbitrary<'a> for LinkedList<A>

--- a/src/foreign/alloc/collections/vec_deque.rs
+++ b/src/foreign/alloc/collections/vec_deque.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::collections::vec_deque::VecDeque,
+    alloc::collections::vec_deque::VecDeque,
 };
 
 impl<'a, A> Arbitrary<'a> for VecDeque<A>

--- a/src/foreign/alloc/ffi/c_str.rs
+++ b/src/foreign/alloc/ffi/c_str.rs
@@ -1,6 +1,12 @@
+#[cfg(feature = "std")]
+use std::ffi::CString;
+
+#[cfg(all(not(feature = "std"), feature = "alloc_ffi_cstring"))]
+use alloc::ffi::CString;
+
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::ffi::CString,
+    alloc::vec::Vec,
 };
 
 impl<'a> Arbitrary<'a> for CString {

--- a/src/foreign/alloc/ffi/mod.rs
+++ b/src/foreign/alloc/ffi/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(any(feature = "std", feature = "alloc_ffi_cstring"))]
 mod c_str;

--- a/src/foreign/alloc/mod.rs
+++ b/src/foreign/alloc/mod.rs
@@ -9,5 +9,6 @@ mod collections;
 mod ffi;
 mod rc;
 mod string;
+#[cfg(target_has_atomic = "ptr")]
 mod sync;
 mod vec;

--- a/src/foreign/alloc/rc.rs
+++ b/src/foreign/alloc/rc.rs
@@ -1,6 +1,6 @@
 use {
     crate::{size_hint, Arbitrary, Result, Unstructured},
-    std::rc::Rc,
+    alloc::rc::Rc,
 };
 
 impl<'a, A> Arbitrary<'a> for Rc<A>

--- a/src/foreign/alloc/string.rs
+++ b/src/foreign/alloc/string.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::string::String,
+    alloc::string::String,
 };
 
 impl<'a> Arbitrary<'a> for String {

--- a/src/foreign/alloc/sync.rs
+++ b/src/foreign/alloc/sync.rs
@@ -1,6 +1,6 @@
 use {
     crate::{size_hint, Arbitrary, Result, Unstructured},
-    std::sync::Arc,
+    alloc::sync::Arc,
 };
 
 impl<'a, A> Arbitrary<'a> for Arc<A>

--- a/src/foreign/alloc/vec.rs
+++ b/src/foreign/alloc/vec.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::vec::Vec,
+    alloc::vec::Vec,
 };
 
 impl<'a, A> Arbitrary<'a> for Vec<A>

--- a/src/foreign/core/mod.rs
+++ b/src/foreign/core/mod.rs
@@ -9,6 +9,8 @@ mod char;
 mod cmp;
 mod iter;
 mod marker;
+#[cfg(any(feature = "std", feature = "core_net"))]
+mod net;
 mod num;
 mod ops;
 mod option;

--- a/src/foreign/core/net.rs
+++ b/src/foreign/core/net.rs
@@ -1,7 +1,10 @@
-use {
-    crate::{size_hint, Arbitrary, Result, Unstructured},
-    std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
-};
+#[cfg(feature = "std")]
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+#[cfg(all(not(feature = "std"), feature = "core_net"))]
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+use crate::{size_hint, Arbitrary, Result, Unstructured};
 
 impl<'a> Arbitrary<'a> for Ipv4Addr {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {

--- a/src/foreign/mod.rs
+++ b/src/foreign/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! [`Arbitrary`]: crate::Arbitrary
 
+#[cfg(feature = "alloc")]
 mod alloc;
 mod core;
+#[cfg(feature = "std")]
 mod std;

--- a/src/foreign/std/collections/hash_map.rs
+++ b/src/foreign/std/collections/hash_map.rs
@@ -1,9 +1,7 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::{
-        collections::hash_map::HashMap,
-        hash::{BuildHasher, Hash},
-    },
+    core::hash::{BuildHasher, Hash},
+    std::collections::hash_map::HashMap,
 };
 
 impl<'a, K, V, S> Arbitrary<'a> for HashMap<K, V, S>

--- a/src/foreign/std/collections/hash_set.rs
+++ b/src/foreign/std/collections/hash_set.rs
@@ -1,9 +1,7 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
-    std::{
-        collections::hash_set::HashSet,
-        hash::{BuildHasher, Hash},
-    },
+    core::hash::{BuildHasher, Hash},
+    std::collections::hash_set::HashSet,
 };
 
 impl<'a, A, S> Arbitrary<'a> for HashSet<A, S>

--- a/src/foreign/std/ffi/os_str.rs
+++ b/src/foreign/std/ffi/os_str.rs
@@ -1,5 +1,6 @@
 use {
     crate::{Arbitrary, Result, Unstructured},
+    alloc::string::String,
     std::ffi::OsString,
 };
 

--- a/src/foreign/std/mod.rs
+++ b/src/foreign/std/mod.rs
@@ -5,6 +5,5 @@
 
 mod collections;
 mod ffi;
-mod net;
 mod path;
 mod sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,13 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(unused)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod error;
 mod foreign;
@@ -49,7 +56,11 @@ impl core::fmt::Display for MaxRecursionReached {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MaxRecursionReached {}
+
+#[cfg(all(not(feature = "std"), feature = "core_error"))]
+impl core::error::Error for MaxRecursionReached {}
 
 /// Generate arbitrary structured values from raw, unstructured data.
 ///
@@ -122,9 +133,9 @@ impl std::error::Error for MaxRecursionReached {}
 ///
 /// ```
 /// # #[cfg(feature = "derive")] mod foo {
-/// # pub struct MyCollection<T> { _t: std::marker::PhantomData<T> }
+/// # pub struct MyCollection<T> { _t: core::marker::PhantomData<T> }
 /// # impl<T> MyCollection<T> {
-/// #     pub fn new() -> Self { MyCollection { _t: std::marker::PhantomData } }
+/// #     pub fn new() -> Self { MyCollection { _t: core::marker::PhantomData } }
 /// #     pub fn insert(&mut self, element: T) {}
 /// # }
 /// use arbitrary::{Arbitrary, Result, Unstructured};

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -67,10 +67,10 @@ pub fn and_all(hints: &[(usize, Option<usize>)]) -> (usize, Option<usize>) {
 /// `lhs` and `rhs` size hints.
 #[inline]
 pub fn or(lhs: (usize, Option<usize>), rhs: (usize, Option<usize>)) -> (usize, Option<usize>) {
-    let lower = std::cmp::min(lhs.0, rhs.0);
+    let lower = core::cmp::min(lhs.0, rhs.0);
     let upper = lhs
         .1
-        .and_then(|lhs| rhs.1.map(|rhs| std::cmp::max(lhs, rhs)));
+        .and_then(|lhs| rhs.1.map(|rhs| core::cmp::max(lhs, rhs)));
     (lower, upper)
 }
 

--- a/src/unstructured.rs
+++ b/src/unstructured.rs
@@ -9,9 +9,9 @@
 //! Wrappers around raw, unstructured bytes.
 
 use crate::{Arbitrary, Error, Result};
-use std::marker::PhantomData;
-use std::ops::ControlFlow;
-use std::{mem, ops};
+use core::marker::PhantomData;
+use core::ops::ControlFlow;
+use core::{mem, ops};
 
 /// A source of unstructured data.
 ///
@@ -186,9 +186,9 @@ impl<'a> Unstructured<'a> {
     ///
     /// ```
     /// use arbitrary::{Arbitrary, Result, Unstructured};
-    /// # pub struct MyCollection<T> { _t: std::marker::PhantomData<T> }
+    /// # pub struct MyCollection<T> { _t: core::marker::PhantomData<T> }
     /// # impl<T> MyCollection<T> {
-    /// #     pub fn with_capacity(capacity: usize) -> Self { MyCollection { _t: std::marker::PhantomData } }
+    /// #     pub fn with_capacity(capacity: usize) -> Self { MyCollection { _t: core::marker::PhantomData } }
     /// #     pub fn insert(&mut self, element: T) {}
     /// # }
     ///
@@ -218,7 +218,7 @@ impl<'a> Unstructured<'a> {
         let byte_size = self.arbitrary_byte_size()?;
         let (lower, upper) = <ElementType as Arbitrary>::size_hint(0);
         let elem_size = upper.unwrap_or(lower * 2);
-        let elem_size = std::cmp::max(1, elem_size);
+        let elem_size = core::cmp::max(1, elem_size);
         Ok(byte_size / elem_size)
     }
 
@@ -424,7 +424,9 @@ impl<'a> Unstructured<'a> {
     /// Selecting a random item from a set:
     ///
     /// ```
-    /// use std::collections::BTreeSet;
+    /// # #[cfg(feature = "std")]
+    /// # {
+    /// use alloc::collections::BTreeSet;
     /// use arbitrary::Unstructured;
     ///
     /// let mut u = Unstructured::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
@@ -433,6 +435,7 @@ impl<'a> Unstructured<'a> {
     /// let choice = u.choose_iter(set.iter()).unwrap();
     ///
     /// println!("chose {}", choice);
+    /// # }
     /// ```
     pub fn choose_iter<T, I>(&mut self, choices: I) -> Result<T>
     where
@@ -556,7 +559,7 @@ impl<'a> Unstructured<'a> {
     /// assert_eq!(buf, [0, 0]);
     /// ```
     pub fn fill_buffer(&mut self, buffer: &mut [u8]) -> Result<()> {
-        let n = std::cmp::min(buffer.len(), self.data.len());
+        let n = core::cmp::min(buffer.len(), self.data.len());
         buffer[..n].copy_from_slice(&self.data[..n]);
         for byte in buffer[n..].iter_mut() {
             *byte = 0;
@@ -672,8 +675,8 @@ impl<'a> Unstructured<'a> {
     /// times the function is called.
     ///
     /// You may break out of the loop early by returning
-    /// `Ok(std::ops::ControlFlow::Break)`. To continue the loop, return
-    /// `Ok(std::ops::ControlFlow::Continue)`.
+    /// `Ok(core::ops::ControlFlow::Break)`. To continue the loop, return
+    /// `Ok(core::ops::ControlFlow::Continue)`.
     ///
     /// # Panics
     ///
@@ -686,7 +689,7 @@ impl<'a> Unstructured<'a> {
     ///
     /// ```
     /// use arbitrary::{Result, Unstructured};
-    /// use std::ops::ControlFlow;
+    /// use core::ops::ControlFlow;
     ///
     /// enum Type {
     ///     /// A boolean type.
@@ -800,7 +803,7 @@ impl<'a, ElementType: Arbitrary<'a>> Iterator for ArbitraryTakeRestIter<'a, Elem
 /// Don't implement this trait yourself.
 pub trait Int:
     Copy
-    + std::fmt::Debug
+    + core::fmt::Debug
     + PartialOrd
     + Ord
     + ops::Sub<Self, Output = Self>
@@ -904,8 +907,12 @@ impl_int! {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::vec;
+
     use super::*;
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_byte_size() {
         let mut u = Unstructured::new(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 6]);


### PR DESCRIPTION
# Objective

- Fixes #208
- Fixes #38
- Supersedes #74
- Supersedes #177

## Solution

- Added `#![no_std]` unconditionally (to ensure a consistent implicit prelude)
- Added `std` and `alloc` features to conditionally enable access to the `std` and `alloc` crates respectively.
- Added `core_error`, `core_net`, and `alloc_ffi_cstring` features which expand `alloc` and `core` to include items previously exclusive to `std`. Note that these features exist to preserve the current MSRV and can be deprecated/made no-ops once MSRV goes beyond 1.81, 1.77, or 1.64 respectively.
- Added a new CI task `check_no_std` which checks for `no_std` compatibility using a target which does not have access to `std` (`x86_64-unknown-none` is chosen arbitrarily, any appropriate target could be used instead).
- Added `alloc_instead_of_core`, `std_instead_of_alloc`, and `std_instead_of_core` Clippy lints to help maintain `no_std` compatibility.
- Updated the derive macro to include a private `extern crate std;` statement, allowing compilation within `no_std` libraries on `std`-compatible targets.
- Switched to `alloc` and `core` over `std` where possible.
- Added appropriate feature gates based on the new features.
- Gated imports of `Arc` behind `target_has_atomic = "ptr"`, allowing compilation on atomically challenged platforms (typical for embedded).

## Migration Guide

If you have disabled default features but rely on functionality now gated behind the `std` feature, enable it.

```toml
# Before
arbitrary = { version = "1.4.1", default-features = "false" }

# After
arbitrary = { version = "1.4.1", default-features = "false", features = ["std"] }
```

## Notes

I've been working on `no_std` support for the Bevy game engine and WGPU. `arbitrary` is used by WGPU and may become an issue for `no_std` efforts in the future. In general, I believe it's good practice to remove reliance on `std` when possible, even if it isn't strictly necessary (it has been noted that fuzzing requires substantially more effort without the standard library, so there is a reluctance to go to the trouble of maintaining this support). With the added lints, it is my experience that maintaining `no_std` support is of minimal concern even for maintainers without previous `no_std` exposure.

As mentioned above, I've added some features which exist purely to preserve the current MSRV while expanding the capabilities of `no_std` to match modern versions of Rust. Since this PR is a breaking change (may require users to add `std` feature), I'm happy to update this PR to remove some/all of those features in favour of just increasing the MSRV. I defer to the maintainers of this project for that decision.