### PR TITLE
Mark `RECURSIVE_COUNT_*` as `const`.

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -60,7 +60,9 @@ fn expand_derive_arbitrary(input: syn::DeriveInput) -> Result<TokenStream> {
         const _: () = {
             ::std::thread_local! {
                 #[allow(non_upper_case_globals)]
-                static #recursive_count: ::core::cell::Cell<u32> = ::core::cell::Cell::new(0);
+                static #recursive_count: ::core::cell::Cell<u32> = const {
+                    ::core::cell::Cell::new(0)
+                };
             }
 
             #[automatically_derived]


### PR DESCRIPTION
From the `thread_local` docs:

> This macro supports a special `const {}` syntax that can be used when
> the initialization expression can be evaluated as a constant. This can
> enable a more efficient thread local implementation that can avoid
> lazy initialization. For types that do not need to be dropped, this
> can enable an even more efficient implementation that does not need to
> track any additional state.

The `RECURSIVE_COUNT_*` values currently don't use this, but they can. This changes the generated code from this:
```
    #[allow(non_upper_case_globals)]
    const RECURSIVE_COUNT_Example: ::std::thread::LocalKey<::core::cell::Cell<u32>> = {
        #[inline]
        fn __init() -> ::core::cell::Cell<u32> {
            ::core::cell::Cell::new(0)
        }
        unsafe {
            ::std::thread::LocalKey::new(const {
                if ::std::mem::needs_drop::<::core::cell::Cell<u32>>() {
                    |init| {
                        #[thread_local]
                        static VAL: ::std::thread::local_impl::LazyStorage<
                            ::core::cell::Cell<u32>,
                            (),
                        > = ::std::thread::local_impl::LazyStorage::new();
                        VAL.get_or_init(init, __init)
                    }
                } else {
                    |init| {
                        #[thread_local]
                        static VAL: ::std::thread::local_impl::LazyStorage<
                            ::core::cell::Cell<u32>,
                            !,
                        > = ::std::thread::local_impl::LazyStorage::new();
                        VAL.get_or_init(init, __init)
                    }
                }
            })
        }
    };
```
to this:
```
    #[allow(non_upper_case_globals)]
    const RECURSIVE_COUNT_Example: ::std::thread::LocalKey<::core::cell::Cell<u32>> = {
        const __INIT: ::core::cell::Cell<u32> = { ::core::cell::Cell::new(0) };
        unsafe {
            ::std::thread::LocalKey::new(const {
                if ::std::mem::needs_drop::<::core::cell::Cell<u32>>() {
                    |_| {
                        #[thread_local]
                        static VAL: ::std::thread::local_impl::EagerStorage<
                            ::core::cell::Cell<u32>,
                        > = ::std::thread::local_impl::EagerStorage::new(__INIT);
                        VAL.get()
                    }
                } else {
                    |_| {
                        #[thread_local]
                        static VAL: ::core::cell::Cell<u32> = __INIT;
                        &VAL
                    }
                }
            })
        }
    };
```
Note in both cases the `else` block is the relevant one because `Cell<u32>` doesn't need drop.