### PR TITLE
Downgrading broken dependencies to fix MSRV CI test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup toolchain add 1.63
+    - name: Downgrade unicode-ident
+      run: cargo update --package unicode-ident --precise 1.0.22
+    - name: Downgrade syn
+      run: cargo update --package syn --precise 2.0.106
+    - name: Downgrade quote
+      run: cargo update --package quote --precise 1.0.41
+    - name: Downgrade proc-macro2
+      run: cargo update --package proc-macro2 --precise 1.0.103
     - name: Build
       run: cargo +1.63 check --lib --all-features
   clippy:


### PR DESCRIPTION
Downgrading syn, quote, and unicode-ident.

unicode-ident 1.0.22
syn 2.0.106
quote 1.0.41

Fish script made to find these version numbers.
Minimum version numbers based on the latest release number of those packages at the last time CI was successful.
 
```fish
#!/usr/bin/env fish
set fish_trace 1
set -x
set quote_version_min 40
set quote_version_max 45
set syn_version_min 104
set syn_version_max 106
# set proc_version_max 117
set unicode_version_max 24
set unicode_version_min 18

for qv in (seq $quote_version_max -1 $quote_version_min)
  cargo update -p quote --precise 1.0.$qv
  for sv in (seq $syn_version_max -1 $syn_version_min)
    cargo update -p syn --precise 2.0.$sv
    for uv in (seq $unicode_version_max -1 $unicode_version_min)
      cargo update -p unicode-ident --precise 1.0.$uv
      if cargo +1.63 check --lib --all-features
        echo "quote($qv) | syn($sv) | unicode($uv)"
        exit 0
      end
    end
  end
end
echo "No viable combination found"
exit 1
```
