### PR TITLE
Bring fix for fully qualified path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.63.0" # Keep in sync with version documented in the README.md
 include = ["Cargo.toml", "CHANGELOG.md", "LICENSE-MIT", "LICENSE-APACHE", "README.md", "src/**/*.rs", "tests/**/*.rs", "examples/**/*.rs"]
 
 [dependencies]
-derive_arbitrary = { version = "~1.4.0", path = "./derive", optional = true }
+derive_arbitrary = { version = "~1.4.1", path = "./derive", optional = true }
 
 [features]
 # Turn this feature on to enable support for `#[derive(Arbitrary)]`.


### PR DESCRIPTION
When a downstream crate has a [minimal-version check], the version of derive_arbitrary that gets pulled in is 1.4.0, which does not carry the fix the fully qualified path on result that was made in de2becf7c6be9f916c9f1663c57bd3e4a84266a8

This bumps the patch version of the derive from arbitrary so that a downstream crate does not have to make a direct dependency expression against `derive_arbitrary`.

minimal-version checks are useful for checking API stability.

[minimal-version check]: <https://github.com/RustCrypto/actions/blob/master/.github/workflows/minimal-versions.yml>